### PR TITLE
RMT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   x86_64-linux-gnu-gcc:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.0.1
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.0.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   x86_64-linux-gnu-gcc:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.0.2
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.0.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,5 +5,11 @@ on:
     branches: [master]
 
 jobs:
+  esp-elf-gcc:
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/esp-elf-gcc.yml@v0.0.4
+    with:
+      path: examples/rmt
+      target: esp32
+
   x86_64-linux-gnu-gcc:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.0.3
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.0.4

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   license:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/license-checker.yml@v0.0.1
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/license-checker.yml@v0.0.2

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   license:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/license-checker.yml@v0.0.2
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/license-checker.yml@v0.0.3

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   license:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/license-checker.yml@v0.0.3
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/license-checker.yml@v0.0.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: release
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  upload_components:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
+      - uses: espressif/upload-components-ci-action@v1
+        with:
+          name: DCC
+          version: ${{ github.ref_name }}
+          namespace: zimo-elektronik
+          api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   tests:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/ctest.yml@v0.0.3
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/ctest.yml@v0.0.4
     with:
       target: DCCTests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,4 +8,6 @@ on:
 
 jobs:
   tests:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/ctest.yml@v0.0.1
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/ctest.yml@v0.0.2
+    with:
+      target: DCCTests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   tests:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/ctest.yml@v0.0.2
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/ctest.yml@v0.0.3
     with:
       target: DCCTests

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/.vscode/ipch
-/build/
+.vscode/ipch
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 FetchContent_Declare(
   CMakeModules
   GIT_REPOSITORY https://github.com/ZIMO-Elektronik/CMakeModules
-  GIT_TAG v0.6.1
+  GIT_TAG v0.7.0
   SOURCE_DIR ${CMAKE_BINARY_DIR}/CMakeModules)
 FetchContent_MakeAvailable(CMakeModules)
 
@@ -63,7 +63,6 @@ endif()
 
 target_common_warnings(DCC INTERFACE)
 
-get_cpm()
 if(NOT TARGET static_math)
   cpmaddpackage(
     NAME

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ include(FetchContent)
 if(ESP_PLATFORM)
   file(GLOB_RECURSE SRC src/*.c)
   idf_component_register(SRCS ${SRC} INCLUDE_DIRS include REQUIRES driver)
+  set_target_properties(${COMPONENT_LIB} PROPERTIES PREFIX "")
+  set_target_properties(
+    ${COMPONENT_LIB} PROPERTIES OUTPUT_NAME
+                                ${CMAKE_STATIC_LIBRARY_PREFIX}${COMPONENT_LIB})
   target_link_libraries(${COMPONENT_LIB} PUBLIC DCC)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 FetchContent_Declare(
   CMakeModules
   GIT_REPOSITORY https://github.com/ZIMO-Elektronik/CMakeModules
-  GIT_TAG v0.5.0
+  GIT_TAG v0.6.1
   SOURCE_DIR ${CMAKE_BINARY_DIR}/CMakeModules)
 FetchContent_MakeAvailable(CMakeModules)
 
@@ -63,6 +63,7 @@ endif()
 
 target_common_warnings(DCC INTERFACE)
 
+get_cpm()
 if(NOT TARGET static_math)
   cpmaddpackage(
     NAME
@@ -78,7 +79,7 @@ if(NOT TARGET static_math)
 endif()
 
 if(NOT TARGET ZTL::ZTL)
-  cpmaddpackage("gh:ZIMO-Elektronik/ZTL@0.18.0")
+  cpmaddpackage("gh:ZIMO-Elektronik/ZTL@0.19.0")
 endif()
 
 target_link_libraries(DCC INTERFACE static_math ZTL::ZTL)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![build](https://github.com/ZIMO-Elektronik/DCC/actions/workflows/build.yml/badge.svg)](https://github.com/ZIMO-Elektronik/DCC/actions/workflows/build.yml) [![tests](https://github.com/ZIMO-Elektronik/DCC/actions/workflows/tests.yml/badge.svg)](https://github.com/ZIMO-Elektronik/DCC/actions/workflows/tests.yml)
 
-<img src="data/images/logo.gif" align="right"/>
+<img src="https://raw.githubusercontent.com/ZIMO-Elektronik/DCC/master/data/images/logo.gif" align="right"/>
 
 DCC is an acronym for [Digital Command Control](https://en.wikipedia.org/wiki/Digital_Command_Control), a standardized protocol for controlling digital model railways. This C++ library of the same name contains platform-independent code to either decode (decoder) or generate (command station) a DCC signal on the track. For both cases, a typical microcontroller timer with microsecond precision is sufficient for implementing a receiver or transmitter class. Also included, but not platform-independent, is an encoder for the [ESP32 RMT](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/rmt.html) peripherals.
 
@@ -328,14 +328,16 @@ Again implementing the [CommandStation](include/dcc/tx/command_station.hpp) conc
     ```
 
 ### ESP32 RMT encoder
-Similar to the other encoders of the [ESP-IDF](https://github.com/espressif/esp-idf) framework, the RMT encoder has only one function to create a new instance. For more information on how to use the encoder please refer to the [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/rmt.html)
+Similar to the other encoders of the [ESP-IDF](https://github.com/espressif/esp-idf) framework, the RMT encoder has only one function to create a new instance. For more information on how to use the encoder please refer to the [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/rmt.html) or the RMT example.
 ```c
 #include <rmt_dcc_encoder.h>
 
-dcc_encoder_config_t encoder_config = {.num_preamble = 17u,
-                                       .bit1_duration = 58u,
-                                       .bit0_duration = 100u,
-                                       .bidi = true};
+dcc_encoder_config_t encoder_config{.num_preamble = 17u,
+                                    .cutoutbit_duration = 60u,
+                                    .bit1_duration = 58u,
+                                    .bit0_duration = 100u,
+                                    .endbit_duration = 58u - 24u,
+                                    .flags{.zimo0 = true}};
 rmt_encoder_handle_t* encoder;
 ESP_ERROR_CHECK(rmt_new_dcc_encoder(&encoder_config, &encoder));
 ```

--- a/examples/rmt/.gitignore
+++ b/examples/rmt/.gitignore
@@ -1,0 +1,5 @@
+build
+managed_components
+dependencies.lock
+sdkconfig
+sdkconfig.old

--- a/examples/rmt/CMakeLists.txt
+++ b/examples/rmt/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.25)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(DCCRmtExample LANGUAGES ASM C CXX)

--- a/examples/rmt/main/CMakeLists.txt
+++ b/examples/rmt/main/CMakeLists.txt
@@ -1,0 +1,2 @@
+file(GLOB_RECURSE SRC *.cpp)
+idf_component_register(SRCS ${SRC} INCLUDE_DIRS .)

--- a/examples/rmt/main/app_main.cpp
+++ b/examples/rmt/main/app_main.cpp
@@ -21,10 +21,11 @@ extern "C" void app_main() {
 
   // New DCC encoder
   dcc_encoder_config_t encoder_config{.num_preamble = 17u,
+                                      .cutoutbit_duration = 60u,
                                       .bit1_duration = 58u,
                                       .bit0_duration = 100u,
                                       .endbit_duration = 58u - 24u,
-                                      .flags{.cutout = true}};
+                                      .flags{.zimo0 = true}};
   rmt_encoder_handle_t rmt_encoder{};
   ESP_ERROR_CHECK(rmt_new_dcc_encoder(&encoder_config, &rmt_encoder));
 

--- a/examples/rmt/main/app_main.cpp
+++ b/examples/rmt/main/app_main.cpp
@@ -1,0 +1,44 @@
+#include <driver/rmt_tx.h>
+#include <esp_log.h>
+#include <esp_task.h>
+#include <rmt_dcc_encoder.h>
+#include <array>
+
+extern "C" void app_main() {
+  printf("DCC RMT encoder example");
+
+  // Setup RMT on GPIO21
+  rmt_tx_channel_config_t chan_config{.gpio_num = GPIO_NUM_21,
+                                      .clk_src = RMT_CLK_SRC_DEFAULT,
+                                      .resolution_hz = 1'000'000u,  // 1MHz
+                                      .mem_block_symbols =
+                                        SOC_RMT_CHANNELS_PER_GROUP *
+                                        SOC_RMT_MEM_WORDS_PER_CHANNEL,
+                                      .trans_queue_depth = 2uz};
+  rmt_channel_handle_t rmt_channel{};
+  ESP_ERROR_CHECK(rmt_new_tx_channel(&chan_config, &rmt_channel));
+  ESP_ERROR_CHECK(rmt_enable(rmt_channel));
+
+  // New DCC encoder
+  dcc_encoder_config_t encoder_config{.num_preamble = 17u,
+                                      .bit1_duration = 58u,
+                                      .bit0_duration = 100u,
+                                      .endbit_duration = 58u - 24u,
+                                      .flags{.cutout = true}};
+  rmt_encoder_handle_t rmt_encoder{};
+  ESP_ERROR_CHECK(rmt_new_dcc_encoder(&encoder_config, &rmt_encoder));
+
+  std::array<char, 4uz> const chunk{
+    0b1100'0000u,
+    0b0011'0000u,
+    0b0000'1100u,
+    0b0000'0011u,
+  };
+  rmt_transmit_config_t rmt_transmit_config{};
+  for (;;)
+    ESP_ERROR_CHECK(rmt_transmit(rmt_channel,
+                                 rmt_encoder,
+                                 data(chunk),
+                                 size(chunk),
+                                 &rmt_transmit_config));
+}

--- a/examples/rmt/main/idf_component.yml
+++ b/examples/rmt/main/idf_component.yml
@@ -1,0 +1,4 @@
+dependencies:
+  ZIMO-Elektronik/DCC:
+    version: "*"
+    override_path: '../../../'

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,11 @@
+description: PA1010D I2C GPS driver
+url: http://zimo.at
+documentation: https://github.com/ZIMO-Elektronik/DCC/blob/master/README.md
+repository: https://github.com/ZIMO-Elektronik/DCC.git
+issues: https://github.com/ZIMO-Elektronik/DCC/issues
+
+maintainers:
+  - "Vincent Hamp <hamp@zimo.at>"
+
+dependencies:
+  idf: ">=5.0.0"

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-description: PA1010D I2C GPS driver
+description: DCC protocol for controlling digital model railways
 url: http://zimo.at
 documentation: https://github.com/ZIMO-Elektronik/DCC/blob/master/README.md
 repository: https://github.com/ZIMO-Elektronik/DCC.git
@@ -6,6 +6,9 @@ issues: https://github.com/ZIMO-Elektronik/DCC/issues
 
 maintainers:
   - "Vincent Hamp <hamp@zimo.at>"
+
+examples:
+  - path: ./examples/rmt
 
 dependencies:
   idf: ">=5.0.0"

--- a/include/dcc/timing.hpp
+++ b/include/dcc/timing.hpp
@@ -16,17 +16,17 @@ namespace dcc {
 
 enum Timing {
   Bit1Min = 52u,           ///< Minimal timing for half a 1-bit
-  Bit1Norm = 58u,          ///< Norm timing for half a 1-bit
+  Bit1 = 58u,              ///< Standard timing for half a 1-bit
   Bit1Max = 64u,           ///< Maximal timing for half a 1-bit
   Bit0Min = 90u,           ///< Minimal timing for half a 0-bit
-  Bit0Norm = 100u,         ///< Norm timing for half a 0-bit
+  Bit0 = 100u,             ///< Standard timing for half a 0-bit
   Bit0Max = 119u,          ///< Maximal timing for half a 0-bit
   Bit0MaxAnalog = 10000u,  ///< Maximal timing for half a 0-bit analog
   BiDiTCSMin = 26u,        ///< Minimal timing for BiDi cutout start
-  BiDiTCS = 29u,           ///< Norm timing for BiDi cutout start
+  BiDiTCS = 29u,           ///< Standard timing for BiDi cutout start
   BiDiTCSMax = 32u,        ///< Maximal timing for BiDi cutout start
   BiDiTCEMin = 454u,       ///< Minimal timing for BiDi cutout end
-  BiDiTCE = 471u,          ///< Norm timing for BiDi cutout end
+  BiDiTCE = 471u,          ///< Standard timing for BiDi cutout end
   BiDiTCEMax = 488u,       ///< Maximal timing for BiDi cutout end
   BiDiTTS1 = 80u,          ///< Minimal timing for BiDi start channel 1
   BiDiTTC1 = 177u,         ///< Maximal timing for BiDi end channel 1

--- a/include/dcc/tx/config.hpp
+++ b/include/dcc/tx/config.hpp
@@ -15,14 +15,14 @@
 namespace dcc::tx {
 
 struct Config {
-  /// Number of preamble bits [17-100]
+  /// Number of preamble bits [17-255]
   uint8_t preamble_bits{DCC_TX_MIN_PREAMBLE_BITS};
 
   /// Duration of 1 bit [52-64]
-  uint8_t bit1_duration{Bit1Norm};
+  uint8_t bit1_duration{Bit1};
 
   /// Duration of 0 bit [90-119]
-  uint8_t bit0_duration{Bit0Norm};
+  uint8_t bit0_duration{Bit0};
 
   /// Enable BiDi
   bool bidi{true};

--- a/include/dcc/tx/crtp_base.hpp
+++ b/include/dcc/tx/crtp_base.hpp
@@ -31,9 +31,9 @@ struct CrtpBase {
   ///
   /// \param  cfg Configuration
   void init(Config cfg) {
-    assert(cfg.preamble_bits >= 17u && cfg.preamble_bits <= 100u &&
-           cfg.bit1_duration >= Bit1Min && cfg.bit1_duration <= Bit1Max &&
-           cfg.bit0_duration >= Bit0Min && cfg.bit0_duration <= Bit0Max);
+    assert(cfg.preamble_bits >= 17u &&                                      //
+           cfg.bit1_duration >= Bit1Min && cfg.bit1_duration <= Bit1Max &&  //
+           cfg.bit0_duration >= Bit0Min && cfg.bit0_duration <= Bit0Max);   //
     _cfg = cfg;
   }
 

--- a/include/rmt_dcc_encoder.h
+++ b/include/rmt_dcc_encoder.h
@@ -22,14 +22,25 @@ typedef struct {
   /// (will get rounded to multiple of 2)
   uint8_t num_preamble;
 
-  /// Duration of 1 bit [52, 64]
+  /// Duration of 1 bit [56, 60]
   uint8_t bit1_duration;
 
-  /// Duration of 0 bit [90, 119]
+  /// Duration of 0 bit [97, 114]
   uint8_t bit0_duration;
 
-  /// Enable BiDi
-  bool bidi;
+  /// Duration of end bit [0, 60]
+  uint8_t endbit_duration;
+
+  struct {
+    /// Invert
+    bool invert : 1;
+
+    /// Cutout
+    bool cutout : 1;
+
+    /// ZIMO 0
+    bool zimo0 : 1;
+  } flags;
 } dcc_encoder_config_t;
 
 /// Create RMT DCC encoder which encodes DCC byte stream into RMT symbols

--- a/include/rmt_dcc_encoder.h
+++ b/include/rmt_dcc_encoder.h
@@ -22,6 +22,9 @@ typedef struct {
   /// (will get rounded to multiple of 2)
   uint8_t num_preamble;
 
+  /// Duration of cutout bit [57, 61]
+  uint16_t cutoutbit_duration;
+
   /// Duration of 1 bit [56, 60]
   uint8_t bit1_duration;
 
@@ -34,9 +37,6 @@ typedef struct {
   struct {
     /// Invert
     bool invert : 1;
-
-    /// Cutout
-    bool cutout : 1;
 
     /// ZIMO 0
     bool zimo0 : 1;

--- a/include/rmt_dcc_encoder.h
+++ b/include/rmt_dcc_encoder.h
@@ -22,7 +22,7 @@ typedef struct {
   /// (will get rounded to multiple of 2)
   uint8_t num_preamble;
 
-  /// Duration of cutout bit [57, 61]
+  /// Optional duration of cutout bit [0 | 57, 61]
   uint16_t cutoutbit_duration;
 
   /// Duration of 1 bit [56, 60]

--- a/include/rmt_dcc_encoder.h
+++ b/include/rmt_dcc_encoder.h
@@ -19,7 +19,6 @@ extern "C" {
 /// DCC encoder configuration
 typedef struct {
   /// Number of preamble bits [17, 255]
-  /// (will get rounded to multiple of 2)
   uint8_t num_preamble;
 
   /// Optional duration of cutout bit [0 | 57, 61]

--- a/src/rmt_dcc_encoder.c
+++ b/src/rmt_dcc_encoder.c
@@ -371,18 +371,20 @@ esp_err_t rmt_new_dcc_encoder(dcc_encoder_config_t const* config,
                               rmt_encoder_handle_t* ret_encoder) {
   esp_err_t ret = ESP_OK;
   rmt_dcc_encoder_t* dcc_encoder = NULL;
-  ESP_GOTO_ON_FALSE(
-    config && ret_encoder &&                                            //
-      config->num_preamble >= 17u &&                                    //
-      config->cutoutbit_duration >= 57u &&                              //
-      config->cutoutbit_duration <= 61u &&                              //
-      config->bit1_duration >= 56u && config->bit1_duration <= 60u &&   //
-      config->bit0_duration >= 97u && config->bit0_duration <= 114u &&  //
-      config->endbit_duration <= 60u,                                   //
-    ESP_ERR_INVALID_ARG,
-    err,
-    TAG,
-    "invalid argument");
+  ESP_GOTO_ON_FALSE(config && ret_encoder &&                    //
+                      config->num_preamble >= 17u &&            //
+                      (!config->cutoutbit_duration ||           //
+                       (config->cutoutbit_duration >= 57u &&    //
+                        config->cutoutbit_duration <= 61u)) &&  //
+                      config->bit1_duration >= 56u &&           //
+                      config->bit1_duration <= 60u &&           //
+                      config->bit0_duration >= 97u &&           //
+                      config->bit0_duration <= 114u &&          //
+                      config->endbit_duration <= 60u,           //
+                    ESP_ERR_INVALID_ARG,
+                    err,
+                    TAG,
+                    "invalid argument");
   dcc_encoder =
     heap_caps_calloc(1, sizeof(rmt_dcc_encoder_t), RMT_MEM_ALLOC_CAPS);
   ESP_GOTO_ON_FALSE(

--- a/src/rmt_dcc_encoder.c
+++ b/src/rmt_dcc_encoder.c
@@ -401,6 +401,10 @@ esp_err_t rmt_new_dcc_encoder(dcc_encoder_config_t const* config,
     TAG,
     "create copy encoder failed");
 
+  // Number of preamble symbols
+  dcc_encoder->num_preamble_symbols = config->num_preamble;
+
+  // Setup RMT symbols
   if (config->cutoutbit_duration)
     dcc_encoder->cutout_symbol = (rmt_symbol_word_t){
       .duration0 = config->cutoutbit_duration,
@@ -427,9 +431,6 @@ esp_err_t rmt_new_dcc_encoder(dcc_encoder_config_t const* config,
       config->endbit_duration ? config->endbit_duration : config->bit1_duration,
     .level1 = 1u ^ config->flags.invert,
   };
-
-  // We can only transmit multiples of 2
-  dcc_encoder->num_preamble_symbols = (config->num_preamble + 1u) / 2u;
 
   // Initial state
   dcc_encoder->state = Zimo0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,6 @@ target_common_warnings(DCCTests PRIVATE)
 
 cpmaddpackage("gh:google/googletest#main")
 
-target_link_libraries(DCCTests PRIVATE DCC::DCC GTest::gtest GTest::gmock)
+target_link_libraries(DCCTests PRIVATE DCC::DCC GTest::gtest_main GTest::gmock)
 
 gtest_discover_tests(DCCTests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ include(GoogleTest)
 file(GLOB_RECURSE SRC *.cpp)
 add_executable(DCCTests ${SRC})
 
-sanitize("address,undefined")
+sanitize(address,undefined)
 
 target_common_warnings(DCCTests PRIVATE)
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,9 +1,0 @@
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-
-int main(int argc, char* argv[]) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::InitGoogleMock(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}


### PR DESCRIPTION
Various RMT encoder changes to allow
- Setting individual cutout bit timings
- Adjusting the second half of an end bit timing
- Flag to invert the entire signal
- Flag to create a ZIMO0