### PR TITLE
fix: standard compliance

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,10 +2,10 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Debug DCCExamples",
+      "name": "Debug DCCReplExample",
       "type": "cppdbg",
       "request": "launch",
-      "program": "${workspaceFolder}/build/examples/DCCExamples",
+      "program": "${workspaceFolder}/build/examples/repl/DCCReplExample",
       "args": [],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,12 +2,6 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "CMake DCCTests Clang",
-      "type": "shell",
-      "isBackground": true,
-      "command": "cmake -Bbuild -GNinja -DCMAKE_TOOLCHAIN_FILE=CMakeModules/src/toolchains/clang.cmake -DCMAKE_BUILD_TYPE=Debug"
-    },
-    {
       "label": "CMake DCCTests",
       "type": "shell",
       "isBackground": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 - Limit number of preamble bits of RMT encoder to 30
 - Rename dcc_encoder_config_t::cutoutbit_duration to bidibit_duration
 - Remove optional mduEntry
+- Bugfix standard compliant CV28
+  - Logon must be enabled by CV28:7 and ignores CV28:1 and CV28:0
+- Bugfix standard compliant RCN-217
+  - Reply with active address in channel 1 (instead of just primary)
+- Bugfix standard compliant RCN-218
+  - Logon address is only temporary
 
 ## 0.32.0
 - Individual timings for namespace dcc::rx and dcc::tx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ if(NOT TARGET static_math)
 endif()
 
 if(NOT TARGET ZTL::ZTL)
-  cpmaddpackage("gh:ZIMO-Elektronik/ZTL@0.19.0")
+  cpmaddpackage(gh:ZIMO-Elektronik/ZTL@0.19.0)
 endif()
 
 target_link_libraries(DCC INTERFACE static_math ZTL::ZTL)

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,3 @@
-- Consist address is never used, although it should be sent in channel 1 in case it's active
 - Literal for converting CV number to index? The "- 1u" everything is fucking ugly
 - dcc::tx::CrtpBase currently pops it's deque at a bad time. Although the design or inplace_deque guarantees that it's not UB it looks funky.
 - Replace `RMT_MEM_ALLOC_CAPS` macro with [`rmt_alloc_encoder_mem`](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/rmt.html#_CPPv421rmt_alloc_encoder_mem6size_t)

--- a/examples/repl/CMakeLists.txt
+++ b/examples/repl/CMakeLists.txt
@@ -3,6 +3,6 @@ add_executable(DCCReplExample ${SRC})
 
 target_common_warnings(DCCReplExample PRIVATE)
 
-cpmaddpackage("gh:daniele77/cli@2.0.2")
+cpmaddpackage(gh:daniele77/cli@2.1.0)
 
 target_link_libraries(DCCReplExample PRIVATE cli::cli DCC::DCC)

--- a/examples/repl/decoder.cpp
+++ b/examples/repl/decoder.cpp
@@ -44,10 +44,11 @@ void Decoder::serviceAck() {}
 void Decoder::transmitBiDi(std::span<uint8_t const>) {}
 
 uint8_t Decoder::readCv(uint32_t cv_addr, [[maybe_unused]] uint8_t byte) {
+  auto const red_byte{
+    static_cast<uint8_t>(cv_addr < size(_cvs) ? _cvs[cv_addr] : 0u)};
   cli::Cli::cout() << "Read CV byte " << cv_addr
-                   << "==" << static_cast<uint32_t>(_cvs[cv_addr])
-                   << PROMPTENDL;
-  return _cvs[cv_addr];
+                   << "==" << static_cast<uint32_t>(red_byte) << PROMPTENDL;
+  return red_byte;
 }
 
 uint8_t Decoder::writeCv(uint32_t cv_addr, uint8_t byte) {

--- a/include/dcc/address.hpp
+++ b/include/dcc/address.hpp
@@ -48,6 +48,8 @@ struct Address {
     AutomaticLogon,  ///< Address is automatic logon
     IdleSystem       ///< Address for system commands
   } type{};
+
+  bool reversed{};  /// Direction reversed
 };
 
 #pragma GCC diagnostic push

--- a/include/dcc/address_group.hpp
+++ b/include/dcc/address_group.hpp
@@ -2,19 +2,24 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-/// Packet
+/// Address group
 ///
-/// \file   dcc/packet.hpp
+/// \file   dcc/address_group.hpp
 /// \author Vincent Hamp
-/// \date   31/01/2022
+/// \date   02/04/2024
 
 #pragma once
 
 #include <cstdint>
-#include <ztl/inplace_vector.hpp>
 
 namespace dcc {
 
-using Packet = ztl::inplace_vector<uint8_t, DCC_MAX_PACKET_SIZE>;
+/// Address group (RCN-218)
+enum class AddressGroup : uint8_t {
+  All = 0b00u,
+  Loco = 0b01u,
+  Acc = 0b10u,
+  Now = 0b11u
+};
 
 }  // namespace dcc

--- a/include/dcc/crc8.hpp
+++ b/include/dcc/crc8.hpp
@@ -47,15 +47,17 @@ inline constexpr std::array<uint8_t, 256uz> crc8_lut{
 
 }  // namespace detail
 
-/// This function calculates CRC8 (Dallas/Maxim). The polynomial representations
-/// is 0x31.
+/// CRC8 (Dallas/Maxim)
+///
+/// The polynomial representations is 0x31.
 ///
 /// \param  byte  Next byte for CRC calculation
 /// \return CRC8
 constexpr uint8_t crc8(uint8_t byte) { return detail::crc8_lut[byte]; }
 
-/// This function calculates CRC8 (Dallas/Maxim). The polynomial representations
-/// is 0x31.
+/// CRC8 (Dallas/Maxim)
+///
+/// The polynomial representations is 0x31.
 ///
 /// \param  bytes Bytes to calculate CRC8 for
 /// \return CRC8
@@ -67,10 +69,11 @@ constexpr uint8_t crc8(std::span<uint8_t const> bytes) {
     [](uint8_t a, uint8_t b) { return crc8(static_cast<uint8_t>(a ^ b)); });
 }
 
-/// This function calculates CRC8 (Dallas/Maxim). The polynomial representations
-/// is 0x31.
+/// CRC8 (Dallas/Maxim)
 ///
-/// \param  bytes Bytes to calculate CRC8 for
+/// The polynomial representations is 0x31.
+///
+/// \param  packet  Packet
 /// \return CRC8
 constexpr uint8_t crc8(Packet const& packet) {
   // Packet checksum is not part of CRC

--- a/include/dcc/exor.hpp
+++ b/include/dcc/exor.hpp
@@ -27,4 +27,13 @@ constexpr uint8_t exor(std::span<uint8_t const> bytes) {
                          [](uint8_t a, uint8_t b) { return a ^ b; });
 }
 
+/// Exclusive disjunction (ex-or)
+///
+/// \param  packet  Packet
+/// \return Ex-or
+constexpr uint8_t exor(Packet const& packet) {
+  // Packet checksum is not part of exor
+  return exor({cbegin(packet), size(packet) - 1uz});
+}
+
 }  // namespace dcc

--- a/include/dcc/utility.hpp
+++ b/include/dcc/utility.hpp
@@ -11,9 +11,14 @@
 #pragma once
 
 #include <cstdint>
+#include <utility>
 #include <ztl/math.hpp>
 #include "address.hpp"
+#include "address_group.hpp"
+#include "crc8.hpp"
+#include "exor.hpp"
 #include "instruction.hpp"
+#include "packet.hpp"
 
 namespace dcc {
 
@@ -34,6 +39,30 @@ constexpr auto data2uint32(uint8_t const* data) {
                                data[2uz] << 8u | data[3uz] << 0u);
 }
 
+/// uint16_t to data
+///
+/// \param  hword Half-word to convert
+/// \param  data  Pointer to write to
+/// \return Pointer after last element
+constexpr auto uint16_2data(uint16_t hword, uint8_t* data) {
+  *data++ = static_cast<uint8_t>((hword & 0xFF00u) >> 8u);
+  *data++ = static_cast<uint8_t>((hword & 0x00FFu) >> 0u);
+  return data;
+}
+
+/// uint32_t to data
+///
+/// \param  word  Word to convert
+/// \param  data  Pointer to write to
+/// \return Pointer after last element
+constexpr auto uint32_2data(uint32_t word, uint8_t* data) {
+  *data++ = static_cast<uint8_t>((word & 0xFF00'0000u) >> 24u);
+  *data++ = static_cast<uint8_t>((word & 0x00FF'0000u) >> 16u);
+  *data++ = static_cast<uint8_t>((word & 0x0000'FF00u) >> 8u);
+  *data++ = static_cast<uint8_t>((word & 0x0000'00FFu) >> 0u);
+  return data;
+}
+
 /// Scale speed from 14, 28 or 126 steps to 255
 ///
 /// \tparam Scale Scaling
@@ -52,6 +81,379 @@ constexpr int32_t scale_speed(int32_t speed)
     return ztl::lerp<int32_t>(speed, 1, Scale, min, max);
   else if constexpr (Scale == 126)
     return ztl::lerp<int32_t>(speed, 0, Scale, 0, max);
+}
+
+/// Make an idle packet
+///
+/// \return Idle packet
+consteval auto make_idle_packet() { return Packet{0xFFu, 0x00u, 0xFFu}; }
+
+/// Make a reset packet
+///
+/// \return Reset packet
+consteval auto make_reset_packet() { return Packet{0x00u, 0x00u, 0x00u}; }
+
+/// Make an advanced operations speed packet
+///
+/// \param  addr  Address
+/// \param  dir   Direction
+/// \param  speed Speed (0-126)
+/// \return Advanced operations speed packet
+constexpr auto make_advanced_operations_speed_packet(Address::value_type addr,
+                                                     int8_t dir,
+                                                     uint8_t speed) {
+  Packet packet{};
+  auto first{begin(packet)};
+  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
+                           first)};
+  *last++ = 0b0011'1111u;
+  auto const r{static_cast<uint32_t>(dir > 0) << 7u};
+  auto const g{speed & 0x7Fu};
+  *last++ = static_cast<uint8_t>(r | g);
+  *last = exor({first, last});
+  packet.resize(static_cast<Packet::size_type>(++last - first));
+  return packet;
+}
+
+/// TODO
+constexpr auto
+make_advanced_operations_restricted_speed_packet(Address::value_type) {
+  Packet packet{};
+  return packet;
+}
+
+/// TODO
+constexpr auto
+make_advanced_operations_analog_function_group_packet(Address::value_type) {
+  Packet packet{};
+  return packet;
+}
+
+/// TODO
+constexpr auto make_speed_and_direction_packet(Address::value_type) {
+  Packet packet{};
+  return packet;
+}
+
+/// Make a function group packet for F4-F0
+///
+/// \param  addr  Address
+/// \param  state F4-F0 state
+/// \return Function group packet for F4-0
+constexpr auto make_function_group_f4_f0_packet(Address::value_type addr,
+                                                uint8_t state) {
+  Packet packet{};
+  auto first{begin(packet)};
+  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
+                           first)};
+  *last++ = static_cast<uint8_t>(0b1000'0000u | (state & 0b1u) << 4u |
+                                 (state & 0x1Fu) >> 1u);
+  *last = exor({first, last});
+  packet.resize(static_cast<Packet::size_type>(++last - first));
+  return packet;
+}
+
+/// Make a function group packet for F8-F5
+///
+/// \param  addr  Address
+/// \param  state F8-F5 state
+/// \return Function group packet for F8-F5
+constexpr auto make_function_group_f8_f5_packet(Address::value_type addr,
+                                                uint8_t state) {
+  Packet packet{};
+  auto first{begin(packet)};
+  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
+                           first)};
+  *last++ = 0b1011'0000u | (state & 0xFu);
+  *last = exor({first, last});
+  packet.resize(static_cast<Packet::size_type>(++last - first));
+  return packet;
+}
+
+/// Make a function group packet for F12-F9
+///
+/// \param  addr  Address
+/// \param  state F12-F9 state
+/// \return Function group packet for F12-F9
+constexpr auto make_function_group_f12_f9_packet(Address::value_type addr,
+                                                 uint8_t state) {
+  Packet packet{};
+  auto first{begin(packet)};
+  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
+                           first)};
+  *last++ = 0b1010'0000u | (state & 0xFu);
+  *last = exor({first, last});
+  packet.resize(static_cast<Packet::size_type>(++last - first));
+  return packet;
+}
+
+/// Make a feature expansion packet for F20-F13
+///
+/// \param  addr  Address
+/// \param  state F20-F13 state
+/// \return Feature expansion packet for F20-F13
+constexpr auto make_feature_expansion_f20_f13_packet(Address::value_type addr,
+                                                     uint8_t state) {
+  Packet packet{};
+  auto first{begin(packet)};
+  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
+                           first)};
+  *last++ = 0b1101'1110u;
+  *last++ = state;
+  *last = exor({first, last});
+  packet.resize(static_cast<Packet::size_type>(++last - first));
+  return packet;
+}
+
+/// Make a feature expansion packet for F28-F21
+///
+/// \param  addr  Address
+/// \param  state F28-F21 state
+/// \return Feature expansion packet for F28-F21
+constexpr auto make_feature_expansion_f28_f21_packet(Address::value_type addr,
+                                                     uint8_t state) {
+  Packet packet{};
+  auto first{begin(packet)};
+  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
+                           first)};
+  *last++ = 0b1101'1111u;
+  *last++ = state;
+  *last = exor({first, last});
+  packet.resize(static_cast<Packet::size_type>(++last - first));
+  return packet;
+}
+
+/// Make a CV access long form packet for verifying CV
+///
+/// \param  addr    Address
+/// \param  cv_addr CV address
+/// \param  byte    CV value
+/// \return CV access long form packet for verifying CV
+constexpr auto make_cv_access_long_verify_packet(Address::value_type addr,
+                                                 uint32_t cv_addr,
+                                                 uint8_t byte = 0u) {
+  Packet packet{};
+  auto first{begin(packet)};
+  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
+                           first)};
+  *last++ = static_cast<uint8_t>(0b1110'0100u | (cv_addr & 0x3FFu) >> 8u);
+  *last++ = static_cast<uint8_t>(cv_addr);
+  *last++ = byte;
+  *last = exor({first, last});
+  packet.resize(static_cast<Packet::size_type>(++last - first));
+  return packet;
+}
+
+/// Make a CV access long form packet for writing CV
+///
+/// \param  addr    Address
+/// \param  cv_addr CV address
+/// \param  byte    CV value
+/// \return CV access long form packet for writing CV
+constexpr auto make_cv_access_long_write_packet(Address::value_type addr,
+                                                uint32_t cv_addr,
+                                                uint8_t byte) {
+  Packet packet{};
+  auto first{begin(packet)};
+  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
+                           first)};
+  *last++ = static_cast<uint8_t>(0b1110'1100u | (cv_addr & 0x3FFu) >> 8u);
+  *last++ = static_cast<uint8_t>(cv_addr);
+  *last++ = byte;
+  *last = exor({first, last});
+  packet.resize(static_cast<Packet::size_type>(++last - first));
+  return packet;
+}
+
+/// Make a CV access long form packet for verifying CV bit
+///
+/// \param  addr    Address
+/// \param  cv_addr CV address
+/// \param  bit     Bit
+/// \param  pos     Bit position
+/// \return CV access long form packet for verifying CV bit
+constexpr auto make_cv_access_long_verify_packet(Address::value_type addr,
+                                                 uint32_t cv_addr,
+                                                 bool bit,
+                                                 uint32_t pos) {
+  Packet packet{};
+  auto first{begin(packet)};
+  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
+                           first)};
+  *last++ = static_cast<uint8_t>(0b1110'1000u | (cv_addr & 0x3FFu) >> 8u);
+  *last++ = static_cast<uint8_t>(cv_addr);
+  auto const d{static_cast<uint32_t>(bit << 3u)};
+  *last++ = static_cast<uint8_t>(0b1110'0000u | d | (pos & 0b111u));
+  *last = exor({first, last});
+  packet.resize(static_cast<Packet::size_type>(++last - first));
+  return packet;
+}
+
+/// Make a CV access long form packet for writing CV bit
+///
+/// \param  addr    Address
+/// \param  cv_addr CV address
+/// \param  bit     Bit
+/// \param  pos     Bit position
+/// \return CV access long form packet for writing CV bit
+constexpr auto make_cv_access_long_write_packet(Address::value_type addr,
+                                                uint32_t cv_addr,
+                                                bool bit,
+                                                uint32_t pos) {
+  Packet packet{};
+  auto first{begin(packet)};
+  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
+                           first)};
+  *last++ = static_cast<uint8_t>(0b1110'1000u | (cv_addr & 0x3FFu) >> 8u);
+  *last++ = static_cast<uint8_t>(cv_addr);
+  auto const d{static_cast<uint32_t>(bit << 3u)};
+  *last++ = static_cast<uint8_t>(0b1111'0000u | d | (pos & 0b111u));
+  *last = exor({first, last});
+  packet.resize(static_cast<Packet::size_type>(++last - first));
+  return packet;
+}
+
+/// Make a CV access long form service packet for verifying CV
+///
+/// \param  cv_addr CV address
+/// \param  byte    CV value
+/// \return CV access long form service packet for verifying CV
+constexpr auto make_cv_access_long_verify_service_packet(uint32_t cv_addr,
+                                                         uint8_t byte) {
+  Packet packet{};
+  auto first{begin(packet)};
+  auto last{first};
+  *last++ = static_cast<uint8_t>(0b0111'0100u | (cv_addr & 0x3FFu) >> 8u);
+  *last++ = static_cast<uint8_t>(cv_addr);
+  *last++ = byte;
+  *last = exor({first, last});
+  packet.resize(static_cast<Packet::size_type>(++last - first));
+  return packet;
+}
+
+/// Make a CV access long form service packet for writing CV
+///
+/// \param  cv_addr CV address
+/// \param  byte    CV value
+/// \return CV access long form service packet for writing CV
+constexpr auto make_cv_access_long_write_service_packet(uint32_t cv_addr,
+                                                        uint8_t byte) {
+  Packet packet{};
+  auto first{begin(packet)};
+  auto last{first};
+  *last++ = static_cast<uint8_t>(0b0111'1100u | (cv_addr & 0x3FFu) >> 8u);
+  *last++ = static_cast<uint8_t>(cv_addr);
+  *last++ = byte;
+  *last = exor({first, last});
+  packet.resize(static_cast<Packet::size_type>(++last - first));
+  return packet;
+}
+
+/// Make a CV access long form service packet for verifying CV bit
+///
+/// \param  cv_addr CV address
+/// \param  bit     Bit
+/// \param  pos     Bit position
+/// \return CV access long form service packet for verifying CV bit
+constexpr auto make_cv_access_long_verify_service_packet(uint32_t cv_addr,
+                                                         bool bit,
+                                                         uint32_t pos) {
+  Packet packet{};
+  auto first{begin(packet)};
+  auto last{first};
+  *last++ = static_cast<uint8_t>(0b0111'1000u | (cv_addr & 0x3FFu) >> 8u);
+  *last++ = static_cast<uint8_t>(cv_addr);
+  auto const d{static_cast<uint32_t>(bit << 3u)};
+  *last++ = static_cast<uint8_t>(0b1110'0000u | d | (pos & 0b111u));
+  *last = exor({first, last});
+  packet.resize(static_cast<Packet::size_type>(++last - first));
+  return packet;
+}
+
+/// Make a CV access long form service packet for writing CV bit
+///
+/// \param  cv_addr CV address
+/// \param  bit     Bit
+/// \param  pos     Bit position
+/// \return CV access long form service packet for writing CV bit
+constexpr auto make_cv_access_long_write_service_packet(uint32_t cv_addr,
+                                                        bool bit,
+                                                        uint32_t pos) {
+  Packet packet{};
+  auto first{begin(packet)};
+  auto last{first};
+  *last++ = static_cast<uint8_t>(0b0111'1000u | (cv_addr & 0x3FFu) >> 8u);
+  *last++ = static_cast<uint8_t>(cv_addr);
+  auto const d{static_cast<uint32_t>(bit << 3u)};
+  *last++ = static_cast<uint8_t>(0b1111'0000u | d | (pos & 0b111u));
+  *last = exor({first, last});
+  packet.resize(static_cast<Packet::size_type>(++last - first));
+  return packet;
+}
+
+/// Make a LOGON_ENABLE packet
+///
+/// \param  gg          Address group
+/// \param  cid         Command station ID
+/// \param  session_id  Session ID
+/// \return LOGON_ENABLE packet
+constexpr auto
+make_logon_enable_packet(AddressGroup gg, uint16_t cid, uint8_t session_id) {
+  Packet packet{};
+  auto first{begin(packet)};
+  auto last{encode_address({254u, Address::AutomaticLogon}, first)};
+  *last++ = static_cast<uint8_t>(0b1111'1100u | std::to_underlying(gg));
+  last = uint16_2data(cid, last);
+  *last++ = session_id;
+  *last = exor({first, last});
+  packet.resize(static_cast<Packet::size_type>(++last - first));
+  return packet;
+}
+
+/// Make a LOGON_SELECT packet
+///
+/// \param  manufacturer_id Manufacturer ID
+/// \param  did             Unique ID
+/// \return LOGON_SELECT packet
+constexpr auto make_logon_select_packet(uint16_t manufacturer_id,
+                                        uint32_t did,
+                                        uint8_t subcommand = 0b1111'1111u) {
+  Packet packet{};
+  auto first{begin(packet)};
+  auto last{encode_address({254u, Address::AutomaticLogon}, first)};
+  *last++ = static_cast<uint8_t>(0b1101'0000u | (manufacturer_id >> 8u));
+  *last++ = static_cast<uint8_t>(manufacturer_id);
+  last = uint32_2data(did, last);
+  *last++ = subcommand;
+  *last = dcc::crc8({first, last});
+  ++last;
+  *last = dcc::exor({first, last});
+  packet.resize(static_cast<Packet::size_type>(++last - first));
+  return packet;
+}
+
+/// Make a LOGON_ASSIGN packet
+///
+/// \param  manufacturer_id Manufacturer ID
+/// \param  did             Unique ID
+/// \param  addr            Address (own encoding!)
+/// \return LOGON_ASSIGN packet
+constexpr auto
+make_logon_assign_packet([[maybe_unused]] uint16_t manufacturer_id,
+                         [[maybe_unused]] uint32_t did,
+                         [[maybe_unused]] uint16_t addr) {
+  Packet packet{};
+  auto first{begin(packet)};
+  auto last{encode_address({254u, Address::AutomaticLogon}, first)};
+  *last++ = static_cast<uint8_t>(0b1110'0000u | (manufacturer_id >> 8u));
+  *last++ = static_cast<uint8_t>(manufacturer_id);
+  last = uint32_2data(did, last);
+  last = uint16_2data(addr, last);
+  *last = dcc::crc8({first, last});
+  ++last;
+  *last = dcc::exor({first, last});
+  packet.resize(static_cast<Packet::size_type>(++last - first));
+  return packet;
 }
 
 }  // namespace dcc

--- a/include/rmt_dcc_encoder.h
+++ b/include/rmt_dcc_encoder.h
@@ -51,12 +51,12 @@ typedef struct {
 ///
 /// \param  config              DCC encoder configuration
 /// \param  ret_encoder         Returned encoder handle
-/// \return ESP_OK              Create RMT DCC encoder successfully
-/// \return ESP_ERR_INVALID_ARG Create RMT DCC encoder failed because of
+/// \retval ESP_OK              Create RMT DCC encoder successfully
+/// \retval ESP_ERR_INVALID_ARG Create RMT DCC encoder failed because of
 ///                             invalid argument
-/// \return ESP_ERR_NO_MEM      Create RMT DCC encoder failed because out of
+/// \retval ESP_ERR_NO_MEM      Create RMT DCC encoder failed because out of
 ///                             memory
-/// \return ESP_FAIL            Create RMT DCC encoder failed because of other
+/// \retval ESP_FAIL            Create RMT DCC encoder failed because of other
 ///                             error
 esp_err_t rmt_new_dcc_encoder(dcc_encoder_config_t const* config,
                               rmt_encoder_handle_t* ret_encoder);

--- a/src/rmt_dcc_encoder.c
+++ b/src/rmt_dcc_encoder.c
@@ -327,10 +327,10 @@ static size_t IRAM_ATTR rmt_encode_dcc(rmt_encoder_t* encoder,
 /// Delete RMT DCC encoder
 ///
 /// \param  encoder             RMT encoder handle
-/// \return ESP_OK              Delete RMT DCC encoder successfully
-/// \return ESP_ERR_INVALID_ARG Delete RMT DCC encoder failed because of invalid
+/// \retval ESP_OK              Delete RMT DCC encoder successfully
+/// \retval ESP_ERR_INVALID_ARG Delete RMT DCC encoder failed because of invalid
 ///                             argument
-/// \return ESP_FAIL            Delete RMT DCC encoder failed because of other
+/// \retval ESP_FAIL            Delete RMT DCC encoder failed because of other
 ///                             error
 static esp_err_t rmt_del_dcc_encoder(rmt_encoder_t* encoder) {
   rmt_dcc_encoder_t* dcc_encoder =
@@ -344,10 +344,10 @@ static esp_err_t rmt_del_dcc_encoder(rmt_encoder_t* encoder) {
 /// Reset RMT DCC encoder
 ///
 /// \param  encoder             RMT encoder handle
-/// \return ESP_OK              Reset RMT DCC encoder successfully
-/// \return ESP_ERR_INVALID_ARG Reset RMT DCC encoder failed because of invalid
+/// \retval ESP_OK              Reset RMT DCC encoder successfully
+/// \retval ESP_ERR_INVALID_ARG Reset RMT DCC encoder failed because of invalid
 ///                             argument
-/// \return ESP_FAIL            Reset RMT DCC encoder failed because of other
+/// \retval ESP_FAIL            Reset RMT DCC encoder failed because of other
 ///                             error
 static esp_err_t rmt_dcc_encoder_reset(rmt_encoder_t* encoder) {
   rmt_dcc_encoder_t* dcc_encoder =
@@ -363,12 +363,12 @@ static esp_err_t rmt_dcc_encoder_reset(rmt_encoder_t* encoder) {
 ///
 /// \param  config              DCC encoder configuration
 /// \param  ret_encoder         Returned encoder handle
-/// \return ESP_OK              Create RMT DCC encoder successfully
-/// \return ESP_ERR_INVALID_ARG Create RMT DCC encoder failed because of
+/// \retval ESP_OK              Create RMT DCC encoder successfully
+/// \retval ESP_ERR_INVALID_ARG Create RMT DCC encoder failed because of
 ///                             invalid argument
-/// \return ESP_ERR_NO_MEM      Create RMT DCC encoder failed because out of
+/// \retval ESP_ERR_NO_MEM      Create RMT DCC encoder failed because out of
 ///                             memory
-/// \return ESP_FAIL            Create RMT DCC encoder failed because of other
+/// \retval ESP_FAIL            Create RMT DCC encoder failed because of other
 ///                             error
 esp_err_t rmt_new_dcc_encoder(dcc_encoder_config_t const* config,
                               rmt_encoder_handle_t* ret_encoder) {

--- a/tests/bidi/encode_decode_test.hpp
+++ b/tests/bidi/encode_decode_test.hpp
@@ -13,5 +13,5 @@ struct EncodeDecodeTest : ::testing::Test {
 };
 
 MATCHER_P(DatagramMatcher, datagram, "") {
-  return std::equal(cbegin(datagram), cend(datagram), arg);
+  return std::ranges::equal(datagram, arg);
 }

--- a/tests/rx/advanced_operations.cpp
+++ b/tests/rx/advanced_operations.cpp
@@ -2,8 +2,6 @@
 
 // 126 speed steps command forward
 TEST_F(RxTest, _126_speed_steps_fwd) {
-  Expectation read_cv{
-    EXPECT_CALL(_mock, readCv(_)).WillOnce(Return(_cvs[29uz - 1uz]))};
   Expectation dir{EXPECT_CALL(_mock, direction(3u, 1))};
   Expectation speed{EXPECT_CALL(_mock, speed(3u, _))};
   Receive(dcc::make_advanced_operations_speed_packet(3u, 1, 10u));
@@ -13,8 +11,6 @@ TEST_F(RxTest, _126_speed_steps_fwd) {
 // 126 speed steps command backward
 TEST_F(RxTest, _126_speed_steps_bwd) {
   {
-    Expectation read_cv{
-      EXPECT_CALL(_mock, readCv(_)).WillOnce(Return(_cvs[29uz - 1uz]))};
     Expectation dir{EXPECT_CALL(_mock, direction(3u, -1))};
     Expectation speed{EXPECT_CALL(_mock, speed(3u, _))};
     Receive(dcc::make_advanced_operations_speed_packet(3u, -1, 10u));
@@ -23,8 +19,6 @@ TEST_F(RxTest, _126_speed_steps_bwd) {
 
   // dir=0 is accepted as backwards as well
   {
-    Expectation read_cv{
-      EXPECT_CALL(_mock, readCv(_)).WillOnce(Return(_cvs[29uz - 1uz]))};
     Expectation dir{EXPECT_CALL(_mock, direction(3u, -1))};
     Expectation speed{EXPECT_CALL(_mock, speed(3u, _))};
     Receive(dcc::make_advanced_operations_speed_packet(3u, 0, 10u));

--- a/tests/rx/bidi_app_adr.cpp
+++ b/tests/rx/bidi_app_adr.cpp
@@ -1,0 +1,70 @@
+#include "bidi_test.hpp"
+
+TEST_F(BiDiTest, app_adr_alternate_id1_id2) {
+  _addrs.received = _addrs.primary;
+
+  // Encode address
+  std::array<uint8_t, 2uz> adr;
+  encode_address(_addrs.received, begin(adr));
+
+  // Make datagram (who the fuck decided that encoding...?)
+  auto adr_high{
+    encode_datagram(make_datagram<Bits::_12>(1u, adr[0uz] & 0b1011'1111u))};
+  auto adr_low{encode_datagram(make_datagram<Bits::_12>(2u, adr[1uz]))};
+
+  InSequence s;
+  for (auto i{0uz}; i < 10uz; ++i) {
+    EXPECT_CALL(*this, transmitBiDi(DatagramMatcher(adr_high))).Times(1);
+    execute();
+    cutoutChannel1();
+
+    EXPECT_CALL(*this, transmitBiDi(DatagramMatcher(adr_low))).Times(1);
+    execute();
+    cutoutChannel1();
+  }
+}
+
+TEST_F(BiDiTest, app_adr_disabled_with_cv28_0) {
+  _cvs[28uz - 1uz] = static_cast<uint8_t>(_cvs[28uz - 1uz] & 0b1111'11110u);
+  _addrs.received = _addrs.primary;
+  SetUp();
+
+  EXPECT_CALL(*this, transmitBiDi(_)).Times(0);
+  execute();
+  cutoutChannel1();
+}
+
+TEST_F(BiDiTest, app_adr_consist) {
+  _cvs[19uz - 1uz] = 1u << 7u | 83u;
+  SetUp();
+
+  _addrs.received = _addrs.consist;
+
+  // Make datagram
+  auto adr_high{encode_datagram(make_datagram<Bits::_12>(1u, 0b0110'0000u))};
+  auto adr_low{encode_datagram(make_datagram<Bits::_12>(2u, _cvs[19uz - 1uz]))};
+
+  EXPECT_CALL(*this, transmitBiDi(DatagramMatcher(adr_high))).Times(1);
+  execute();
+  cutoutChannel1();
+
+  EXPECT_CALL(*this, transmitBiDi(DatagramMatcher(adr_low))).Times(1);
+  execute();
+  cutoutChannel1();
+}
+
+TEST_F(BiDiTest, app_adr_long_consist_not_supported) {
+  _cvs[19uz - 1uz] = 83u;
+  _cvs[20uz - 1uz] = 12u;
+  SetUp();
+
+  _addrs.received = _addrs.consist;
+
+  EXPECT_CALL(*this, transmitBiDi(_)).Times(0);
+  execute();
+  cutoutChannel1();
+
+  EXPECT_CALL(*this, transmitBiDi(_)).Times(0);
+  execute();
+  cutoutChannel1();
+}

--- a/tests/rx/bidi_app_pom.cpp
+++ b/tests/rx/bidi_app_pom.cpp
@@ -1,10 +1,21 @@
 #include "bidi_test.hpp"
 
 TEST_F(BiDiTest, app_pom) {
-  uint8_t value{42u};
+  auto value{static_cast<uint8_t>(rand())};
   pom(value);
   _addrs.received = _addrs.primary;
   auto datagram{encode_datagram(make_datagram<Bits::_12>(0u, value))};
-  EXPECT_CALL(*this, transmitBiDi(DatagramMatcher(datagram))).Times(Exactly(1));
+  EXPECT_CALL(*this, transmitBiDi(DatagramMatcher(datagram))).Times(1);
+  cutoutChannel2();
+}
+
+TEST_F(BiDiTest, app_pom_disabled_with_cv28_1) {
+  _cvs[28uz - 1uz] = static_cast<uint8_t>(_cvs[28uz - 1uz] & 0b1111'11101u);
+  _addrs.received = _addrs.primary;
+  SetUp();
+
+  pom(static_cast<uint8_t>(rand()));
+  _addrs.received = _addrs.primary;
+  EXPECT_CALL(*this, transmitBiDi(_)).Times(0);
   cutoutChannel2();
 }

--- a/tests/rx/bidi_app_tos.cpp
+++ b/tests/rx/bidi_app_tos.cpp
@@ -2,19 +2,30 @@
 #include "bidi_test.hpp"
 
 TEST_F(BiDiTest, app_tos) {
-  for (auto i{0u}; i < 30.0 / 10E-3; ++i) tipOffSearch();
+  // Does not require CV28:1
+  _cvs[28uz - 1uz] = static_cast<uint8_t>(_cvs[28uz - 1uz] & 0b1111'11101u);
+  _addrs.received = _addrs.primary;
+  SetUp();
+
   _addrs.received = {0u, dcc::Address::Broadcast};
 
+  // Make sure to get past backoff (see RCN-218)
+  for (auto i{0u}; i < 30.0 / 10E-3; ++i) tipOffSearch();
+
+  // Encode address
+  std::array<uint8_t, 2uz> adr;
+  encode_address(_addrs.primary, begin(adr));
+
   // Make datagram
-  auto adr_high{encode_datagram(make_datagram<Bits::_12>(1u, 0u))};
-  auto adr_low{
-    encode_datagram(make_datagram<Bits::_12>(2u, _addrs.primary & 0xFFu))};
+  auto adr_high{
+    encode_datagram(make_datagram<Bits::_12>(1u, adr[0uz] & 0b1011'1111u))};
+  auto adr_low{encode_datagram(make_datagram<Bits::_12>(2u, adr[1uz]))};
   auto time{encode_datagram(make_datagram<Bits::_12>(14u, 0u))};
   std::array<uint8_t, size(adr_high) + size(adr_low) + size(time)> datagram{};
   auto it{std::copy(cbegin(adr_high), cend(adr_high), begin(datagram))};
   it = std::copy(cbegin(adr_low), cend(adr_low), it);
   std::copy(cbegin(time), cend(time), it);
 
-  EXPECT_CALL(*this, transmitBiDi(DatagramMatcher(datagram))).Times(AtLeast(1));
+  EXPECT_CALL(*this, transmitBiDi(DatagramMatcher(datagram))).Times(1);
   cutoutChannel2();
 }

--- a/tests/rx/bidi_backoff.cpp
+++ b/tests/rx/bidi_backoff.cpp
@@ -1,29 +1,29 @@
 #include "bidi_backoff_test.hpp"
 
 TEST_F(BiDiBackoffTest, repeated_values_stay_below_max_range) {
-  EXPECT_LT(countTillFalse(CHAR_BIT), CHAR_BIT);
-  EXPECT_LT(countTillFalse(CHAR_BIT << 1), CHAR_BIT << 1);
-  EXPECT_LT(countTillFalse(CHAR_BIT << 2), CHAR_BIT << 2);
-  EXPECT_LT(countTillFalse(CHAR_BIT << 3), CHAR_BIT << 3);
+  EXPECT_LT(CountTillFalse(CHAR_BIT), CHAR_BIT);
+  EXPECT_LT(CountTillFalse(CHAR_BIT << 1), CHAR_BIT << 1);
+  EXPECT_LT(CountTillFalse(CHAR_BIT << 2), CHAR_BIT << 2);
+  EXPECT_LT(CountTillFalse(CHAR_BIT << 3), CHAR_BIT << 3);
 
   // Range can't get bigger than CHAR_BIT << 3 (64)
-  EXPECT_LT(countTillFalse(CHAR_BIT << 4), CHAR_BIT << 3);
+  EXPECT_LT(CountTillFalse(CHAR_BIT << 4), CHAR_BIT << 3);
 
   // Range can be reset
   _backoff = {};
-  EXPECT_LT(countTillFalse(CHAR_BIT), CHAR_BIT);
+  EXPECT_LT(CountTillFalse(CHAR_BIT), CHAR_BIT);
 }
 
 TEST_F(BiDiBackoffTest, reset) {
-  EXPECT_LT(countTillFalse(CHAR_BIT), CHAR_BIT);
-  EXPECT_LT(countTillFalse(CHAR_BIT << 1), CHAR_BIT << 1);
-  EXPECT_LT(countTillFalse(CHAR_BIT << 2), CHAR_BIT << 2);
-  EXPECT_LT(countTillFalse(CHAR_BIT << 3), CHAR_BIT << 3);
+  EXPECT_LT(CountTillFalse(CHAR_BIT), CHAR_BIT);
+  EXPECT_LT(CountTillFalse(CHAR_BIT << 1), CHAR_BIT << 1);
+  EXPECT_LT(CountTillFalse(CHAR_BIT << 2), CHAR_BIT << 2);
+  EXPECT_LT(CountTillFalse(CHAR_BIT << 3), CHAR_BIT << 3);
 
   // Range can't get bigger than CHAR_BIT << 3 (64)
-  EXPECT_LT(countTillFalse(CHAR_BIT << 4), CHAR_BIT << 3);
+  EXPECT_LT(CountTillFalse(CHAR_BIT << 4), CHAR_BIT << 3);
 
   // Range can be reset
   _backoff = {};
-  EXPECT_LT(countTillFalse(CHAR_BIT), CHAR_BIT);
+  EXPECT_LT(CountTillFalse(CHAR_BIT), CHAR_BIT);
 }

--- a/tests/rx/bidi_backoff_test.cpp
+++ b/tests/rx/bidi_backoff_test.cpp
@@ -10,7 +10,7 @@ BiDiBackoffTest::BiDiBackoffTest() {
 
 BiDiBackoffTest::~BiDiBackoffTest() {}
 
-int BiDiBackoffTest::countTillFalse(int max) {
+int BiDiBackoffTest::CountTillFalse(int max) {
   int i{};
   for (; i < max; ++i)
     if (!_backoff) break;

--- a/tests/rx/bidi_backoff_test.hpp
+++ b/tests/rx/bidi_backoff_test.hpp
@@ -7,11 +7,11 @@
 using dcc::rx::bidi::Backoff;
 
 struct BiDiBackoffTest : ::testing::Test {
+protected:
   BiDiBackoffTest();
   virtual ~BiDiBackoffTest();
 
-  int countTillFalse(int max);
+  int CountTillFalse(int max);
 
-protected:
   Backoff _backoff{};
 };

--- a/tests/rx/bidi_test.cpp
+++ b/tests/rx/bidi_test.cpp
@@ -1,26 +1,31 @@
 #include "bidi_test.hpp"
 
 BiDiTest::BiDiTest() {
-  _cvs[29uz - 1uz] = 0b1000u;   // Decoder configuration
-  _cvs[1uz - 1uz] = 3u;         // Primary address
-  _cvs[19uz - 1uz] = 0u;        // Consist address low byte
-  _cvs[20uz - 1uz] = 0u;        // Consist address high byte
-  _cvs[15uz - 1uz] = 0u;        // Lock
-  _cvs[16uz - 1uz] = 0u;        // Lock compare
-  _cvs[28uz - 1uz] = 0b11u;     // RailCom
-  _cvs[250uz - 1uz] = 0xAAu;    // Decoder ID 1
-  _cvs[251uz - 1uz] = 0xBBu;    // Decoder ID 2
-  _cvs[252uz - 1uz] = 0xCCu;    // Decoder ID 3
-  _cvs[253uz - 1uz] = 0xDDu;    // Decoder ID 4
-  _cvs[65297uz - 1uz] = 0x00u;  // Logon address low byte
-  _cvs[65298uz - 1uz] = 0x2Au;  // Logon address high byte
-  _cvs[65299uz - 1uz] = 0xABu;  // CID high byte
-  _cvs[65300uz - 1uz] = 0xCDu;  // CID low byte
-  _cvs[65301uz - 1uz] = 0x2A;   // Session ID
+  _cvs[29uz - 1uz] = 0b0010'1000u;  // Decoder configuration
+  _cvs[1uz - 1uz] = 3u;             // Primary address
+  _cvs[17uz - 1uz] = 203u;          // Extended address low byte
+  _cvs[18uz - 1uz] = 219u;          // Extended address high byte
+  _cvs[19uz - 1uz] = 0u;            // Consist address low byte
+  _cvs[20uz - 1uz] = 0u;            // Consist address high byte
+  _cvs[15uz - 1uz] = 0u;            // Lock
+  _cvs[16uz - 1uz] = 0u;            // Lock compare
+  _cvs[28uz - 1uz] = 0b1000'0011u;  // RailCom
+  _cvs[250uz - 1uz] = 0xAAu;        // Decoder ID 1
+  _cvs[251uz - 1uz] = 0xBBu;        // Decoder ID 2
+  _cvs[252uz - 1uz] = 0xCCu;        // Decoder ID 3
+  _cvs[253uz - 1uz] = 0xDDu;        // Decoder ID 4
+  _cvs[65297uz - 1uz] = 0xABu;      // CID high byte
+  _cvs[65298uz - 1uz] = 0xCDu;      // CID low byte
+  _cvs[65299uz - 1uz] = 0x2Au;      // Session ID
+}
 
+BiDiTest::~BiDiTest() {}
+
+void BiDiTest::SetUp() {
   Expectation read_cv{EXPECT_CALL(*this, readCv(_))
                         .WillOnce(Return(_cvs[29uz - 1uz]))
-                        .WillOnce(Return(_cvs[1uz - 1uz]))
+                        .WillOnce(Return(_cvs[17uz - 1uz]))
+                        .WillOnce(Return(_cvs[18uz - 1uz]))
                         .WillOnce(Return(_cvs[19uz - 1uz]))
                         .WillOnce(Return(_cvs[20uz - 1uz]))
                         .WillOnce(Return(_cvs[15uz - 1uz]))
@@ -32,10 +37,6 @@ BiDiTest::BiDiTest() {
                         .WillOnce(Return(_cvs[253uz - 1uz]))
                         .WillOnce(Return(_cvs[65297uz - 1uz]))
                         .WillOnce(Return(_cvs[65298uz - 1uz]))
-                        .WillOnce(Return(_cvs[65299uz - 1uz]))
-                        .WillOnce(Return(_cvs[65300uz - 1uz]))
-                        .WillOnce(Return(_cvs[65301uz - 1uz]))};
+                        .WillOnce(Return(_cvs[65299uz - 1uz]))};
   init();
 }
-
-BiDiTest::~BiDiTest() {}

--- a/tests/rx/bidi_test.hpp
+++ b/tests/rx/bidi_test.hpp
@@ -7,10 +7,12 @@ using namespace ::testing;
 
 // BiDi test fixture
 struct BiDiTest : ::testing::Test, RxMock {
+protected:
   BiDiTest();
   virtual ~BiDiTest();
 
-private:
+  void SetUp() override;
+
   std::array<uint8_t, smath::pow(2uz, 16uz)> _cvs{};
 };
 

--- a/tests/rx/logon.cpp
+++ b/tests/rx/logon.cpp
@@ -1,0 +1,24 @@
+#include "rx_test.hpp"
+
+TEST_F(RxTest, logon_with_new_cid_and_session_id) {
+  EXPECT_CALL(_mock, transmitBiDi(_)).Times(3 * 2);
+
+  // Enable
+  Receive(dcc::make_logon_enable_packet(dcc::AddressGroup::Now, 0u, 0u));
+  Cutout();
+
+  // Select
+  Receive(dcc::make_logon_select_packet(dcc::zimo_id, _did));
+  Cutout();
+
+  // Assign address 1000
+  Receive(
+    dcc::make_logon_assign_packet(dcc::zimo_id, _did, (0b11 << 14u) | 1000u));
+  Cutout();
+
+  // Execute commands to address 1000
+  EXPECT_CALL(_mock, direction(3u, -1));
+  EXPECT_CALL(_mock, speed(3u, _));
+  Receive(dcc::make_advanced_operations_speed_packet(1000u, -1, 10u));
+  Execute();
+}

--- a/tests/rx/rx_test.cpp
+++ b/tests/rx/rx_test.cpp
@@ -2,22 +2,20 @@
 #include <algorithm>
 
 RxTest::RxTest() {
-  _cvs[29uz - 1uz] = 0b1010u;   // Decoder configuration
-  _cvs[1uz - 1uz] = 3u;         // Primary address
-  _cvs[19uz - 1uz] = 0u;        // Consist address low byte
-  _cvs[20uz - 1uz] = 0u;        // Consist address high byte
-  _cvs[15uz - 1uz] = 0u;        // Lock
-  _cvs[16uz - 1uz] = 0u;        // Lock compare
-  _cvs[28uz - 1uz] = 0b11u;     // RailCom
-  _cvs[250uz - 1uz] = 0xAAu;    // Decoder ID 1
-  _cvs[251uz - 1uz] = 0xBBu;    // Decoder ID 2
-  _cvs[252uz - 1uz] = 0xCCu;    // Decoder ID 3
-  _cvs[253uz - 1uz] = 0xDDu;    // Decoder ID 4
-  _cvs[65297uz - 1uz] = 0x00u;  // Logon address low byte
-  _cvs[65298uz - 1uz] = 0x2Au;  // Logon address high byte
-  _cvs[65299uz - 1uz] = 0xABu;  // CID high byte
-  _cvs[65300uz - 1uz] = 0xCDu;  // CID low byte
-  _cvs[65301uz - 1uz] = 0x2A;   // Session ID
+  _cvs[29uz - 1uz] = 0b1010u;       // Decoder configuration
+  _cvs[1uz - 1uz] = 3u;             // Primary address
+  _cvs[19uz - 1uz] = 0u;            // Consist address low byte
+  _cvs[20uz - 1uz] = 0u;            // Consist address high byte
+  _cvs[15uz - 1uz] = 0u;            // Lock
+  _cvs[16uz - 1uz] = 0u;            // Lock compare
+  _cvs[28uz - 1uz] = 0b1000'0011u;  // RailCom
+  _cvs[250uz - 1uz] = static_cast<uint8_t>(_did >> 24u);   // Decoder ID 1
+  _cvs[251uz - 1uz] = static_cast<uint8_t>(_did >> 16u);   // Decoder ID 2
+  _cvs[252uz - 1uz] = static_cast<uint8_t>(_did >> 8u);    // Decoder ID 3
+  _cvs[253uz - 1uz] = static_cast<uint8_t>(_did >> 0u);    // Decoder ID 4
+  _cvs[65297uz - 1uz] = static_cast<uint8_t>(_cid >> 8u);  // CID high byte
+  _cvs[65298uz - 1uz] = static_cast<uint8_t>(_cid >> 0u);  // CID low byte
+  _cvs[65299uz - 1uz] = _session_id;                       // Session ID
 }
 
 RxTest::~RxTest() {}
@@ -37,9 +35,7 @@ void RxTest::SetUp() {
                         .WillOnce(Return(_cvs[253uz - 1uz]))
                         .WillOnce(Return(_cvs[65297uz - 1uz]))
                         .WillOnce(Return(_cvs[65298uz - 1uz]))
-                        .WillOnce(Return(_cvs[65299uz - 1uz]))
-                        .WillOnce(Return(_cvs[65300uz - 1uz]))
-                        .WillOnce(Return(_cvs[65301uz - 1uz]))};
+                        .WillOnce(Return(_cvs[65299uz - 1uz]))};
   _mock.init();
 }
 
@@ -54,6 +50,11 @@ void RxTest::Receive(dcc::tx::Timings const& timings) {
 }
 
 void RxTest::Execute() { _mock.execute(); }
+
+void RxTest::Cutout() {
+  _mock.cutoutChannel1();
+  _mock.cutoutChannel2();
+}
 
 void RxTest::EnterServiceMode() {
   Expectation service_mode_hook{EXPECT_CALL(_mock, serviceModeHook(true))};

--- a/tests/rx/rx_test.hpp
+++ b/tests/rx/rx_test.hpp
@@ -8,6 +8,7 @@ using namespace ::testing;
 
 // Receive test fixture
 struct RxTest : ::testing::Test {
+protected:
   RxTest();
   virtual ~RxTest();
 
@@ -16,6 +17,7 @@ struct RxTest : ::testing::Test {
   void Receive(dcc::Packet const& packet);
   void Receive(dcc::tx::Timings const& timings);
   void Execute();
+  void Cutout();
 
   void EnterServiceMode();
 
@@ -28,7 +30,9 @@ struct RxTest : ::testing::Test {
     return dis(gen);
   }
 
-protected:
   RxMock _mock;
   std::array<uint8_t, smath::pow(2uz, 16uz)> _cvs{};
+  uint32_t _did{0xAABBCCDDu};
+  uint16_t _cid{0xABCDu};
+  uint8_t _session_id{0x2Au};
 };


### PR DESCRIPTION
- Limit number of preamble bits of RMT encoder to 30
- Rename dcc_encoder_config_t::cutoutbit_duration to bidibit_duration
- Remove optional mduEntry
- Bugfix standard compliant CV28
  - Logon must be enabled by CV28:7 and ignores CV28:1 and CV28:0
- Bugfix standard compliant RCN-217
  - Reply with active address in channel 1 (instead of just primary)
- Bugfix standard compliant RCN-218
  - Logon address is only temporary