### PR TITLE
fix: POM ID0 datagrams may only be sent in BiDi cutouts following CV access commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.35.0
+- Add `dcc::Packet` and `std::span` overloads to `decode_address`
+- Add `dcc::Packet` and `std::span` overloads to `decode_instruction`
+- Block `rx::CrtpBase::execute` during BiDi cutout
+- Bugfix POM ID0 datagrams may only be sent in BiDi cutouts following CV access commands ([#15](https://github.com/ZIMO-Elektronik/DCC/issues/15))
+
 ## 0.34.0
 - Add datagram method to `rx::bidi::CrtpBase` to queue dyn (ID7) datagrams
 - Replace `int32_t` direction (1, -1) with `bool` (1, 0)

--- a/README.md
+++ b/README.md
@@ -290,7 +290,9 @@ Implementing the [Decoder](include/dcc/rx/decoder.hpp) concept alone is not enou
         vTaskDelay(pdMS_TO_TICKS(5u));
       }
     }
-    ```
+    ```    
+> [!WARNING]  
+> During the BiDi cutout, execution is temporarily blocked and may return immediately.
 
 #### Optional
 There are various optional methods that can be implemented if required. One of them are asynchronous CV methods that contain a callback as the last parameter. These methods allow to return immediately and execute the callback at a later point in time. Another addition can enable or disable high-current BiDi if the corresponding bit is set in CV29. And last but not least, the east-west direction according to [RCN-212](https://normen.railcommunity.de/RCN-212.pdf) is supported.

--- a/include/dcc/bidi/datagram.hpp
+++ b/include/dcc/bidi/datagram.hpp
@@ -55,6 +55,14 @@ inline constexpr std::array<uint8_t, 256uz> decode_lut{
 
 }  // namespace detail
 
+/// Instruction understood and will be executed
+///
+/// For some stupid, incomprehensible reason, there are two versions of ACK.
+inline constexpr std::array<uint8_t, 2uz> acks{0b0000'1111u, 0b1111'0000u};
+
+/// Instruction received correctly but not supported
+inline constexpr uint8_t nack{0b0011'1100u};
+
 /// Enumeration to specify datagram bits
 enum class Bits { _12 = 12uz, _18 = 18uz, _24 = 24uz, _36 = 36uz, _48 = 48uz };
 

--- a/include/dcc/instruction.hpp
+++ b/include/dcc/instruction.hpp
@@ -11,6 +11,8 @@
 #pragma once
 
 #include <cstdint>
+#include <span>
+#include "packet.hpp"
 
 namespace dcc {
 
@@ -55,6 +57,23 @@ constexpr Instruction decode_instruction(InputIt first) {
   }
   if (*first == 0b1111'1110u) return Instruction::Logon;
   return Instruction::UnknownService;
+}
+
+/// Decode instruction
+///
+/// \param  bytes Raw bytes
+/// \return Instruction
+constexpr Instruction decode_instruction(std::span<uint8_t const> bytes) {
+  return decode_instruction(cbegin(bytes));
+}
+
+/// Decode instruction
+///
+/// \param  packet  Packet
+/// \return Instruction
+constexpr Instruction decode_instruction(Packet const& packet) {
+  auto const offset{packet[0uz] >= 128u && packet[1uz] <= 252u};
+  return decode_instruction(cbegin(packet) + 1 + offset);
 }
 
 }  // namespace dcc

--- a/include/dcc/utility.hpp
+++ b/include/dcc/utility.hpp
@@ -102,8 +102,8 @@ constexpr auto make_advanced_operations_speed_packet(Address::value_type addr,
                                                      uint8_t rggggggg) {
   Packet packet{};
   auto first{begin(packet)};
-  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
-                           first)};
+  auto last{encode_address(
+    {addr, addr <= 127u ? Address::Short : Address::Long}, first)};
   *last++ = 0b0011'1111u;
   *last++ = rggggggg;
   *last = exor({first, last});
@@ -140,8 +140,8 @@ constexpr auto make_function_group_f4_f0_packet(Address::value_type addr,
                                                 uint8_t state) {
   Packet packet{};
   auto first{begin(packet)};
-  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
-                           first)};
+  auto last{encode_address(
+    {addr, addr <= 127u ? Address::Short : Address::Long}, first)};
   *last++ = static_cast<uint8_t>(0b1000'0000u | (state & 0b1u) << 4u |
                                  (state & 0x1Fu) >> 1u);
   *last = exor({first, last});
@@ -158,8 +158,8 @@ constexpr auto make_function_group_f8_f5_packet(Address::value_type addr,
                                                 uint8_t state) {
   Packet packet{};
   auto first{begin(packet)};
-  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
-                           first)};
+  auto last{encode_address(
+    {addr, addr <= 127u ? Address::Short : Address::Long}, first)};
   *last++ = 0b1011'0000u | (state & 0xFu);
   *last = exor({first, last});
   packet.resize(static_cast<Packet::size_type>(++last - first));
@@ -175,8 +175,8 @@ constexpr auto make_function_group_f12_f9_packet(Address::value_type addr,
                                                  uint8_t state) {
   Packet packet{};
   auto first{begin(packet)};
-  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
-                           first)};
+  auto last{encode_address(
+    {addr, addr <= 127u ? Address::Short : Address::Long}, first)};
   *last++ = 0b1010'0000u | (state & 0xFu);
   *last = exor({first, last});
   packet.resize(static_cast<Packet::size_type>(++last - first));
@@ -192,8 +192,8 @@ constexpr auto make_feature_expansion_f20_f13_packet(Address::value_type addr,
                                                      uint8_t state) {
   Packet packet{};
   auto first{begin(packet)};
-  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
-                           first)};
+  auto last{encode_address(
+    {addr, addr <= 127u ? Address::Short : Address::Long}, first)};
   *last++ = 0b1101'1110u;
   *last++ = state;
   *last = exor({first, last});
@@ -210,8 +210,8 @@ constexpr auto make_feature_expansion_f28_f21_packet(Address::value_type addr,
                                                      uint8_t state) {
   Packet packet{};
   auto first{begin(packet)};
-  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
-                           first)};
+  auto last{encode_address(
+    {addr, addr <= 127u ? Address::Short : Address::Long}, first)};
   *last++ = 0b1101'1111u;
   *last++ = state;
   *last = exor({first, last});
@@ -228,8 +228,8 @@ constexpr auto make_binary_state_short_packet(Address::value_type addr,
                                               uint8_t dlllllll) {
   Packet packet{};
   auto first{begin(packet)};
-  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
-                           first)};
+  auto last{encode_address(
+    {addr, addr <= 127u ? Address::Short : Address::Long}, first)};
   *last++ = 0b1101'1101u;
   *last++ = dlllllll;
   *last = exor({first, last});
@@ -248,8 +248,8 @@ constexpr auto make_binary_state_long_packet(Address::value_type addr,
                                              uint8_t hhhhhhhh) {
   Packet packet{};
   auto first{begin(packet)};
-  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
-                           first)};
+  auto last{encode_address(
+    {addr, addr <= 127u ? Address::Short : Address::Long}, first)};
   *last++ = 0b1100'0000u;
   *last++ = dlllllll;
   *last++ = hhhhhhhh;
@@ -269,8 +269,8 @@ constexpr auto make_cv_access_long_verify_packet(Address::value_type addr,
                                                  uint8_t byte = 0u) {
   Packet packet{};
   auto first{begin(packet)};
-  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
-                           first)};
+  auto last{encode_address(
+    {addr, addr <= 127u ? Address::Short : Address::Long}, first)};
   *last++ = static_cast<uint8_t>(0b1110'0100u | (cv_addr & 0x3FFu) >> 8u);
   *last++ = static_cast<uint8_t>(cv_addr);
   *last++ = byte;
@@ -290,8 +290,8 @@ constexpr auto make_cv_access_long_write_packet(Address::value_type addr,
                                                 uint8_t byte) {
   Packet packet{};
   auto first{begin(packet)};
-  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
-                           first)};
+  auto last{encode_address(
+    {addr, addr <= 127u ? Address::Short : Address::Long}, first)};
   *last++ = static_cast<uint8_t>(0b1110'1100u | (cv_addr & 0x3FFu) >> 8u);
   *last++ = static_cast<uint8_t>(cv_addr);
   *last++ = byte;
@@ -313,8 +313,8 @@ constexpr auto make_cv_access_long_verify_packet(Address::value_type addr,
                                                  uint32_t pos) {
   Packet packet{};
   auto first{begin(packet)};
-  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
-                           first)};
+  auto last{encode_address(
+    {addr, addr <= 127u ? Address::Short : Address::Long}, first)};
   *last++ = static_cast<uint8_t>(0b1110'1000u | (cv_addr & 0x3FFu) >> 8u);
   *last++ = static_cast<uint8_t>(cv_addr);
   auto const d{static_cast<uint32_t>(bit << 3u)};
@@ -337,8 +337,8 @@ constexpr auto make_cv_access_long_write_packet(Address::value_type addr,
                                                 uint32_t pos) {
   Packet packet{};
   auto first{begin(packet)};
-  auto last{encode_address({addr, addr < 128u ? Address::Short : Address::Long},
-                           first)};
+  auto last{encode_address(
+    {addr, addr <= 127u ? Address::Short : Address::Long}, first)};
   *last++ = static_cast<uint8_t>(0b1110'1000u | (cv_addr & 0x3FFu) >> 8u);
   *last++ = static_cast<uint8_t>(cv_addr);
   auto const d{static_cast<uint32_t>(bit << 3u)};

--- a/tests/instruction.cpp
+++ b/tests/instruction.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+#include <dcc/dcc.hpp>
+
+TEST(instruction, decode_instruction_short_address) {
+  auto packet{dcc::make_cv_access_long_verify_packet(3u, 0u)};
+  EXPECT_EQ(dcc::decode_instruction(packet), dcc::Instruction::CvLong);
+}
+
+TEST(instruction, decode_instruction_long_address) {
+  auto packet{dcc::make_cv_access_long_verify_packet(1337u, 0u)};
+  EXPECT_EQ(dcc::decode_instruction(packet), dcc::Instruction::CvLong);
+}

--- a/tests/rx/decoder_lock.cpp
+++ b/tests/rx/decoder_lock.cpp
@@ -4,10 +4,10 @@ TEST_F(RxTest, cv15_not_equal_cv15_activates_decoder_lock) {
   _cvs[15uz - 1uz] = 1u;
   _cvs[16uz - 1uz] = 2u;
   SetUp();
+
   auto cv_addr{RandomInterval(30u, smath::pow(2u, 10u) - 1u)};
   auto cv_value{RandomInterval<uint8_t>(0u, 255u)};
-  Expectation can_not_write_cv{
-    EXPECT_CALL(_mock, writeCv(cv_addr, cv_value)).Times(0)};
+  EXPECT_CALL(_mock, writeCv(cv_addr, cv_value)).Times(0);
   ReceiveAndExecuteTwoIdenticalCvWritePackets(cv_addr, cv_value);
 }
 
@@ -15,6 +15,7 @@ TEST_F(RxTest, cv15_zero_deactivates_decoder_lock) {
   _cvs[15uz - 1uz] = 0u;
   _cvs[16uz - 1uz] = 1u;
   SetUp();
+
   auto cv_addr{RandomInterval(30u, smath::pow(2u, 10u) - 1u)};
   auto cv_value{RandomInterval<uint8_t>(0u, 255u)};
   EXPECT_CALL(_mock, writeCv(cv_addr, cv_value));
@@ -25,6 +26,7 @@ TEST_F(RxTest, cv16_zero_deactivates_decoder_lock) {
   _cvs[15uz - 1uz] = 42u;
   _cvs[16uz - 1uz] = 0u;
   SetUp();
+
   auto cv_addr{RandomInterval(30u, smath::pow(2u, 10u) - 1u)};
   auto cv_value{RandomInterval<uint8_t>(0u, 255u)};
   EXPECT_CALL(_mock, writeCv(cv_addr, cv_value));

--- a/tests/rx/logon.cpp
+++ b/tests/rx/logon.cpp
@@ -19,7 +19,7 @@ TEST_F(RxTest, logon_with_new_cid) {
   Cutout();
 
   // Execute commands to address 1000
-  EXPECT_CALL(_mock, writeCv(_, _)).Times(5);
+  EXPECT_CALL(_mock, writeCv(_, _)).Times(7);
   EXPECT_CALL(_mock, direction(_addrs.primary.value, false));
   EXPECT_CALL(_mock, speed(_addrs.primary.value, _));
   Receive(dcc::make_advanced_operations_speed_packet(1000u, 0u));
@@ -31,7 +31,7 @@ TEST_F(RxTest, logon_with_known_cid_and_session_id_le_4) {
   Logon();
 
   // Execute commands to address 1000
-  EXPECT_CALL(_mock, writeCv(_, _)).Times(5);
+  EXPECT_CALL(_mock, writeCv(_, _)).Times(7);
   EXPECT_CALL(_mock, direction(_addrs.primary.value, false));
   EXPECT_CALL(_mock, speed(_addrs.primary.value, _));
   Receive(dcc::make_advanced_operations_speed_packet(_addrs.logon, 0u));
@@ -61,7 +61,7 @@ TEST_F(RxTest, logon_with_known_cid_and_session_id_gt_4) {
   Cutout();
 
   // Execute commands to address 1000
-  EXPECT_CALL(_mock, writeCv(_, _)).Times(5);
+  EXPECT_CALL(_mock, writeCv(_, _)).Times(7);
   EXPECT_CALL(_mock, direction(_addrs.primary.value, false));
   EXPECT_CALL(_mock, speed(_addrs.primary.value, _));
   Receive(dcc::make_advanced_operations_speed_packet(1000u, 0u));

--- a/tests/rx/rx_test.cpp
+++ b/tests/rx/rx_test.cpp
@@ -53,7 +53,12 @@ void RxTest::Receive(dcc::tx::Timings const& timings) {
                           [this](uint32_t time) { _mock.receive(time); });
 }
 
-void RxTest::Execute() { _mock.execute(); }
+void RxTest::Execute() {
+  // Receive additional preamble bit before calling execute to avoid being
+  // inside a cutout and getting execution blocked!
+  _mock.receive(dcc::rx::Timing::Bit1);
+  _mock.execute();
+}
 
 void RxTest::Cutout() {
   _mock.cutoutChannel1();

--- a/tests/rx/write_bit.cpp
+++ b/tests/rx/write_bit.cpp
@@ -9,7 +9,7 @@ TEST_F(RxTest, write_bit_operations_mode) {
     _addrs.primary, cv_addr, bit, position)};
 
   // 2 or more identical packets
-  Expectation write_cv{EXPECT_CALL(_mock, writeCv(cv_addr, bit, position))};
+  EXPECT_CALL(_mock, writeCv(cv_addr, bit, position));
   for (auto i{0uz}; i < 2uz; ++i) {
     Receive(packet);
     Execute();
@@ -27,9 +27,8 @@ TEST_F(RxTest, write_bit_service_mode) {
     dcc::make_cv_access_long_write_service_packet(cv_addr, bit, position)};
 
   // 5 or more identical packets
-  Expectation write_cv{
-    EXPECT_CALL(_mock, writeCv(cv_addr, bit, position)).WillOnce(Return(bit))};
-  Expectation ack{EXPECT_CALL(_mock, serviceAck())};
+  EXPECT_CALL(_mock, writeCv(cv_addr, bit, position)).WillOnce(Return(bit));
+  EXPECT_CALL(_mock, serviceAck());
   for (auto i{0uz}; i < 5uz; ++i) {
     Receive(packet);
     Execute();

--- a/tests/rx/write_byte.cpp
+++ b/tests/rx/write_byte.cpp
@@ -5,7 +5,7 @@ TEST_F(RxTest, write_byte_operations_mode) {
   auto cv_addr{RandomInterval(30u, smath::pow(2u, 10u) - 1u)};
   auto cv_value{RandomInterval<uint8_t>(0u, 255u)};
 
-  Expectation write_cv{EXPECT_CALL(_mock, writeCv(cv_addr, cv_value))};
+  EXPECT_CALL(_mock, writeCv(cv_addr, cv_value));
   ReceiveAndExecuteTwoIdenticalCvWritePackets(cv_addr, cv_value);
 }
 
@@ -15,8 +15,7 @@ TEST_F(RxTest, write_byte_operations_mode_requires_two_identical_packets) {
   auto packet{
     dcc::make_cv_access_long_write_packet(_addrs.primary, cv_addr, cv_value)};
 
-  Expectation do_not_write_cv{
-    EXPECT_CALL(_mock, writeCv(cv_addr, cv_value)).Times(0)};
+  EXPECT_CALL(_mock, writeCv(cv_addr, cv_value)).Times(0);
   Receive(packet);
   Execute();
 }
@@ -30,7 +29,7 @@ TEST_F(RxTest, write_byte_service_mode) {
   auto packet{dcc::make_cv_access_long_write_service_packet(cv_addr, cv_value)};
 
   // 5 or more identical packets
-  Expectation write_cv{EXPECT_CALL(_mock, writeCv(cv_addr, cv_value))};
+  EXPECT_CALL(_mock, writeCv(cv_addr, cv_value));
   for (auto i{0uz}; i < 5uz; ++i) {
     Receive(packet);
     Execute();


### PR DESCRIPTION
Fixes #15 