### PR TITLE
fix: typo in decode_instruction results in incorrect decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.35.3
+- Bugfix typo in `decode_instruction` results in incorrect decoding ([#27](https://github.com/ZIMO-Elektronik/DCC/issues/27))
+
 ## 0.35.2
 - Ignore `-Warray-bounds` for `decode_address`
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 FetchContent_Declare(
   CMakeModules
   GIT_REPOSITORY "https://github.com/ZIMO-Elektronik/CMakeModules"
-  GIT_TAG v0.9.1
+  GIT_TAG v0.9.2
   SOURCE_DIR ${CMAKE_BINARY_DIR}/CMakeModules)
 FetchContent_MakeAvailable(CMakeModules)
 
@@ -127,7 +127,7 @@ if(PROJECT_IS_TOP_LEVEL)
   add_subdirectory(examples)
   file(
     DOWNLOAD
-    "https://github.com/ZIMO-Elektronik/.clang-format/raw/master/.clang-format"
+    "https://github.com/ZIMO-Elektronik/.github/raw/master/data/.clang-format"
     ${CMAKE_CURRENT_LIST_DIR}/.clang-format)
   file(GLOB_RECURSE SRC examples/*.[ch]pp include/*.[ch]pp src/*.[ch]pp
        tests/*.[ch]pp)

--- a/include/dcc/instruction.hpp
+++ b/include/dcc/instruction.hpp
@@ -72,7 +72,7 @@ constexpr Instruction decode_instruction(std::span<uint8_t const> bytes) {
 /// \param  packet  Packet
 /// \return Instruction
 constexpr Instruction decode_instruction(Packet const& packet) {
-  auto const offset{packet[0uz] >= 128u && packet[1uz] <= 252u};
+  auto const offset{packet[0uz] >= 128u && packet[0uz] <= 252u};
   return decode_instruction(cbegin(packet) + 1 + offset);
 }
 

--- a/include/dcc/utility.hpp
+++ b/include/dcc/utility.hpp
@@ -67,7 +67,7 @@ constexpr auto uint32_2data(uint32_t word, uint8_t* data) {
 ///
 /// \tparam Scale Scaling
 /// \param  speed Speed
-/// \raturn Scaled speed
+/// \return Scaled speed
 template<int32_t Scale>
 constexpr int32_t scale_speed(int32_t speed)
   requires(Scale == 14 || Scale == 28 || Scale == 126)

--- a/tests/instruction.cpp
+++ b/tests/instruction.cpp
@@ -7,6 +7,13 @@ TEST(instruction, decode_instruction_short_address) {
 }
 
 TEST(instruction, decode_instruction_long_address) {
-  auto packet{dcc::make_cv_access_long_verify_packet(1337u, 0u)};
-  EXPECT_EQ(dcc::decode_instruction(packet), dcc::Instruction::CvLong);
+  {
+    auto packet{dcc::make_cv_access_long_verify_packet(1022u, 0u)};
+    EXPECT_EQ(dcc::decode_instruction(packet), dcc::Instruction::CvLong);
+  }
+
+  {
+    auto packet{dcc::make_cv_access_long_verify_packet(1337u, 0u)};
+    EXPECT_EQ(dcc::decode_instruction(packet), dcc::Instruction::CvLong);
+  }
 }


### PR DESCRIPTION
Fix #27