### PR TITLE
feat: add `dcc::Address` overloads of `make_*_packet` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## 0.37.0
+- Add `dcc::Address` overloads of `make_*_packet` functions
+  - Allows to e.g. send address 100-127 as type `Long`
 - Add `DCC_TX_MIN_BIDI_BIT_TIMING` definition
 - Add `DCC_TX_MAX_BIDI_BIT_TIMING` definition
 
@@ -95,7 +97,7 @@
 - CV15/16 the values 0 can no longer activate the lock
 
 ## 0.24.1
-- Short and long addresses are considered equal if their values are
+- `Short` and `Long` addresses are considered equal if their values are
 - `make_*_packet` functions
 - Bugfix QoS datagram wasn't thread safe
 
@@ -179,7 +181,7 @@
 - Default paged mode index register to 1
 
 ## 0.7
-- Bugfix short addresses must also work in CV17/18
+- Bugfix `Short` addresses must also work in CV17/18
 
 ## 0.6
 - Added register mode

--- a/include/dcc/address.hpp
+++ b/include/dcc/address.hpp
@@ -69,7 +69,7 @@ constexpr Address decode_address(InputIt first) {
   else if (*first <= 127u) return {*first, Address::Short};
   // 128-191
   else if (*first <= 191u)
-    return {*first, Address::Accessory};  // TODO most likely wrong?
+    return {*first, Address::Accessory};  /// \todo wrong?
   // 192-231
   else if (*first <= 231u) {
     auto const a13_8{*first++};
@@ -118,7 +118,7 @@ constexpr OutputIt encode_address(Address addr, OutputIt first) {
     case Address::Broadcast: *first++ = 0u; break;
     case Address::Short: *first++ = static_cast<uint8_t>(addr); break;
     case Address::Accessory:
-      // TODO (see decode_address)
+      /// \todo see decode_address
       break;
     case Address::Long:
       *first++ = static_cast<uint8_t>(0b1100'0000u | addr >> 8u);

--- a/include/dcc/rx/crtp_base.hpp
+++ b/include/dcc/rx/crtp_base.hpp
@@ -431,9 +431,8 @@ private:
   }
 
   /// Execute decoder control
-  void decoderControl(std::span<uint8_t const>) const {
-    // TODO
-  }
+  /// \todo
+  void decoderControl(std::span<uint8_t const>) const {}
 
   /// Execute consist control
   ///
@@ -498,7 +497,7 @@ private:
 
       // Analog function group
       case 0b0011'1101u:
-        // TODO
+        /// \todo
         break;
     }
   }
@@ -601,12 +600,12 @@ private:
 
       // System time (3 bytes)
       case 0b1100'0010u:
-        // TODO
+        /// \todo
         break;
 
       // Command station properties (4 bytes)
       case 0b1100'0011u:
-        // TODO
+        /// \todo
         break;
 
       // F20-F19-F18-F17-F16-F15-F14-F13
@@ -835,9 +834,8 @@ private:
   }
 
   /// Time
-  void time(std::span<uint8_t const>) const {
-    // TODO
-  }
+  /// \todo
+  void time(std::span<uint8_t const>) const {}
 
   /// Execute binary state
   ///
@@ -1036,7 +1034,7 @@ private:
     }
     // RCN-217 can't encode CV20 yet
     else {
-      // TODO
+      /// \todo
     }
   }
 

--- a/include/dcc/tx/crtp_base.hpp
+++ b/include/dcc/tx/crtp_base.hpp
@@ -64,9 +64,9 @@ struct CrtpBase {
     // or BiDi timings
     else if (_cfg.flags.bidi && _bidi_count <= 4uz) return bidiTiming();
 
-    // TODO theoretically deque could be popped here safely?
-    // we'd just need to check whether packet doesn't point to idle_packet and
-    // deque ain't empty?
+    /// \todo theoretically deque could be popped here safely?
+    /// we'd just need to check whether packet doesn't point to idle_packet and
+    /// deque ain't empty?
 
     // Deque is empty, send idle packet
     if (empty(_deque)) _packet = &_idle_packet;


### PR DESCRIPTION
Add `dcc::Address` overloads of `make_*_packet` functions.