### PR TITLE
Accessory & KLUG features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
-##
-- Add `Accessory` address encoding/decoding
+## 0.40.0
+- Add `size` and `capacity` methods to `tx::CrtpBase`
+- Remove async CV bit operations
+- Async CV operations are only used in service mode
+- Add `BasicAccessory` and `ExtendedAccessory` address
+- Rename `Short` to `BasicLoco` address
+- Rename `Long` to `ExtendedLoco` address
 
 ## 0.39.0
 - Bugfix disable LOGON_ENABLE after LOGON_SELECT ([#38](https://github.com/ZIMO-Elektronik/DCC/issues/38))

--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ This library is meant to be consumed with CMake,
 
 ```cmake
 # Either by including it with CPM
-cpmaddpackage("gh:ZIMO-Elektronik/DCC@0.39.0")
+cpmaddpackage("gh:ZIMO-Elektronik/DCC@0.40.0")
 
 # or the FetchContent module
 FetchContent_Declare(
   DCC
   GIT_REPOSITORY "https://github.com/ZIMO-Elektronik/DCC"
-  GIT_TAG v0.39.0)
+  GIT_TAG v0.40.0)
 
 target_link_libraries(YourTarget PRIVATE DCC::DCC)
 ```
@@ -131,7 +131,7 @@ or, on [ESP32 platforms](https://www.espressif.com/en/products/socs/esp32), with
 ```yaml
 dependencies:
   zimo-elektronik/dcc:
-    version: "0.39.0"
+    version: "0.40.0"
 ```
 
 A number of [options](CMakeLists.txt) are provided to configure various sizes such as the receiver deque length or the maximum packet length. When RAM becomes scarce, deque lengths can be reduced. On the other hand, if the processing of the commands is too slow and cannot be done every few milliseconds, it can make sense to lengthen the deques and batch process several commands at once. Otherwise, we recommend sticking with the defaults.
@@ -190,7 +190,7 @@ dcc> Address 3: set speed 18
 On [ESP32 platforms](https://www.espressif.com/en/products/socs/esp32) examples from the [examples](https://github.com/ZIMO-Elektronik/DCC/raw/master/examples) subfolder can be built directly using the [IDF Frontend](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/tools/idf-py.html).
 
 ```sh
-idf.py create-project-from-example "zimo-elektronik/dcc^0.39.0:esp32"
+idf.py create-project-from-example "zimo-elektronik/dcc^0.40.0:esp32"
 ```
 
 #### STM32

--- a/examples/repl/src/main.cpp
+++ b/examples/repl/src/main.cpp
@@ -60,7 +60,7 @@ void command_station_task(FiFo<dcc::Packet>* fifo) {
 // REPL task reading user input
 void repl_task(FiFo<dcc::Packet>* fifo) {
   // Start with primary address 3
-  dcc::Address addr{3u, dcc::Address::Short};
+  dcc::Address addr{3u, dcc::Address::BasicLoco};
 
   auto root{std::make_unique<cli::Menu>("dcc")};
 

--- a/include/dcc/address_group.hpp
+++ b/include/dcc/address_group.hpp
@@ -15,7 +15,7 @@
 namespace dcc {
 
 /// Address group (RCN-218)
-enum class AddressGroup : uint8_t {
+enum struct AddressGroup : uint8_t {
   All = 0b00u,
   Loco = 0b01u,
   Acc = 0b10u,

--- a/include/dcc/bidi/datagram.hpp
+++ b/include/dcc/bidi/datagram.hpp
@@ -64,7 +64,7 @@ inline constexpr std::array<uint8_t, 2uz> acks{0b0000'1111u, 0b1111'0000u};
 inline constexpr uint8_t nack{0b0011'1100u};
 
 /// Enumeration to specify datagram bits
-enum class Bits { _12 = 12uz, _18 = 18uz, _24 = 24uz, _36 = 36uz, _48 = 48uz };
+enum struct Bits { _12 = 12uz, _18 = 18uz, _24 = 24uz, _36 = 36uz, _48 = 48uz };
 
 /// Convert datagram bits to size
 ///

--- a/include/dcc/instruction.hpp
+++ b/include/dcc/instruction.hpp
@@ -16,7 +16,7 @@
 
 namespace dcc {
 
-enum class Instruction : uint8_t {
+enum struct Instruction : uint8_t {
   UnknownService,     ///< Instruction is unknown or service
   DecoderControl,     ///< Instruction is decoder control
   ConsistControl,     ///< Instruction is consist control

--- a/include/dcc/rx/async_readable.hpp
+++ b/include/dcc/rx/async_readable.hpp
@@ -17,15 +17,9 @@
 namespace dcc::rx {
 
 template<typename T>
-concept AsyncReadable = requires(T t,
-                                 uint32_t cv_addr,
-                                 uint8_t byte,
-                                 bool bit,
-                                 uint32_t pos,
-                                 std::function<void(uint8_t)> byte_cb,
-                                 std::function<void(bool)> bit_cb) {
-  { t.readCv(cv_addr, byte, byte_cb) } -> std::same_as<void>;
-  { t.readCv(cv_addr, bit, pos, bit_cb) } -> std::same_as<void>;
+concept AsyncReadable = requires(
+  T t, uint32_t cv_addr, uint8_t byte, std::function<void(uint8_t)> cb) {
+  { t.readCv(cv_addr, byte, cb) } -> std::same_as<void>;
 };
 
 } // namespace dcc::rx

--- a/include/dcc/rx/async_writable.hpp
+++ b/include/dcc/rx/async_writable.hpp
@@ -17,15 +17,9 @@
 namespace dcc::rx {
 
 template<typename T>
-concept AsyncWritable = requires(T t,
-                                 uint32_t cv_addr,
-                                 uint8_t byte,
-                                 bool bit,
-                                 uint32_t pos,
-                                 std::function<void(uint8_t)> byte_cb,
-                                 std::function<void(bool)> bit_cb) {
-  { t.writeCv(cv_addr, byte, byte_cb) } -> std::same_as<void>;
-  { t.writeCv(cv_addr, bit, pos, bit_cb) } -> std::same_as<void>;
+concept AsyncWritable = requires(
+  T t, uint32_t cv_addr, uint8_t byte, std::function<void(uint8_t)> cb) {
+  { t.writeCv(cv_addr, byte, cb) } -> std::same_as<void>;
 };
 
 } // namespace dcc::rx

--- a/include/dcc/tx/command_station.hpp
+++ b/include/dcc/tx/command_station.hpp
@@ -16,7 +16,6 @@ namespace dcc::tx {
 
 template<typename T>
 concept CommandStation = requires(T t, bool N, bool P) {
-  { t.trackOutputs(N, P) } -> std::same_as<void>;
   { t.biDiStart() } -> std::same_as<void>;
   { t.biDiChannel1() } -> std::same_as<void>;
   { t.biDiChannel2() } -> std::same_as<void>;

--- a/include/dcc/tx/timings.hpp
+++ b/include/dcc/tx/timings.hpp
@@ -22,7 +22,7 @@ namespace dcc::tx {
 
 using Timings =
   ztl::inplace_vector<uint16_t,
-                      (std::numeric_limits<uint8_t>::max() +   // Preamble
+                      (DCC_TX_MAX_PREAMBLE_BITS +              // Preamble
                        1uz +                                   // Startbit
                        DCC_MAX_PACKET_SIZE * (CHAR_BIT + 1uz)) // Data
                         * 2uz>;                                // Halfbit

--- a/include/dcc/tx/track_outputs.hpp
+++ b/include/dcc/tx/track_outputs.hpp
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// Track outputs
+///
+/// \file   dcc/tx/track_outputs.hpp
+/// \author Vincent Hamp
+/// \date   16/01/2024
+
+#pragma once
+
+#include <concepts>
+
+namespace dcc::tx {
+
+template<typename T>
+concept TrackOutputs = requires(T t, bool N, bool P) {
+  { t.trackOutputs(N, P) } -> std::same_as<void>;
+};
+
+} // namespace dcc::tx

--- a/include/dcc/utility.hpp
+++ b/include/dcc/utility.hpp
@@ -131,7 +131,7 @@ constexpr auto make_advanced_operations_speed_direction_and_functions_packet(
   uint8_t f7_f0,
   std::unsigned_integral auto... fs) {
   return make_advanced_operations_speed_direction_and_functions_packet(
-    {addr, addr <= 127u ? Address::Short : Address::Long},
+    {addr, addr <= 127u ? Address::BasicLoco : Address::ExtendedLoco},
     rggggggg,
     f7_f0,
     fs...);
@@ -162,7 +162,8 @@ constexpr auto make_advanced_operations_speed_packet(Address addr,
 constexpr auto make_advanced_operations_speed_packet(Address::value_type addr,
                                                      uint8_t rggggggg) {
   return make_advanced_operations_speed_packet(
-    {addr, addr <= 127u ? Address::Short : Address::Long}, rggggggg);
+    {addr, addr <= 127u ? Address::BasicLoco : Address::ExtendedLoco},
+    rggggggg);
 }
 
 /// \todo
@@ -214,7 +215,7 @@ constexpr auto make_speed_and_direction_packet(Address addr, uint8_t rggggg) {
 constexpr auto make_speed_and_direction_packet(Address::value_type addr,
                                                uint8_t rggggg) {
   return make_speed_and_direction_packet(
-    {addr, addr <= 127u ? Address::Short : Address::Long}, rggggg);
+    {addr, addr <= 127u ? Address::BasicLoco : Address::ExtendedLoco}, rggggg);
 }
 
 /// Make a function group packet for F4-F0
@@ -241,7 +242,7 @@ constexpr auto make_function_group_f4_f0_packet(Address addr, uint8_t state) {
 constexpr auto make_function_group_f4_f0_packet(Address::value_type addr,
                                                 uint8_t state) {
   return make_function_group_f4_f0_packet(
-    {addr, addr <= 127u ? Address::Short : Address::Long}, state);
+    {addr, addr <= 127u ? Address::BasicLoco : Address::ExtendedLoco}, state);
 }
 
 /// Make a function group packet for F8-F5
@@ -267,7 +268,7 @@ constexpr auto make_function_group_f8_f5_packet(Address addr, uint8_t state) {
 constexpr auto make_function_group_f8_f5_packet(Address::value_type addr,
                                                 uint8_t state) {
   return make_function_group_f8_f5_packet(
-    {addr, addr <= 127u ? Address::Short : Address::Long}, state);
+    {addr, addr <= 127u ? Address::BasicLoco : Address::ExtendedLoco}, state);
 }
 
 /// Make a function group packet for F12-F9
@@ -293,7 +294,7 @@ constexpr auto make_function_group_f12_f9_packet(Address addr, uint8_t f12_f9) {
 constexpr auto make_function_group_f12_f9_packet(Address::value_type addr,
                                                  uint8_t f12_f9) {
   return make_function_group_f12_f9_packet(
-    {addr, addr <= 127u ? Address::Short : Address::Long}, f12_f9);
+    {addr, addr <= 127u ? Address::BasicLoco : Address::ExtendedLoco}, f12_f9);
 }
 
 /// Make a feature expansion packet for F20-F13
@@ -321,7 +322,7 @@ constexpr auto make_feature_expansion_f20_f13_packet(Address addr,
 constexpr auto make_feature_expansion_f20_f13_packet(Address::value_type addr,
                                                      uint8_t f20_f13) {
   return make_feature_expansion_f20_f13_packet(
-    {addr, addr <= 127u ? Address::Short : Address::Long}, f20_f13);
+    {addr, addr <= 127u ? Address::BasicLoco : Address::ExtendedLoco}, f20_f13);
 }
 
 /// Make a feature expansion packet for F28-F21
@@ -349,7 +350,7 @@ constexpr auto make_feature_expansion_f28_f21_packet(Address addr,
 constexpr auto make_feature_expansion_f28_f21_packet(Address::value_type addr,
                                                      uint8_t f28_f21) {
   return make_feature_expansion_f28_f21_packet(
-    {addr, addr <= 127u ? Address::Short : Address::Long}, f28_f21);
+    {addr, addr <= 127u ? Address::BasicLoco : Address::ExtendedLoco}, f28_f21);
 }
 
 /// Make a binary state short packet
@@ -376,7 +377,8 @@ constexpr auto make_binary_state_short_packet(Address addr, uint8_t dlllllll) {
 constexpr auto make_binary_state_short_packet(Address::value_type addr,
                                               uint8_t dlllllll) {
   return make_binary_state_short_packet(
-    {addr, addr <= 127u ? Address::Short : Address::Long}, dlllllll);
+    {addr, addr <= 127u ? Address::BasicLoco : Address::ExtendedLoco},
+    dlllllll);
 }
 
 /// Make a binary state long packet
@@ -409,7 +411,9 @@ constexpr auto make_binary_state_long_packet(Address::value_type addr,
                                              uint8_t dlllllll,
                                              uint8_t hhhhhhhh) {
   return make_binary_state_long_packet(
-    {addr, addr <= 127u ? Address::Short : Address::Long}, dlllllll, hhhhhhhh);
+    {addr, addr <= 127u ? Address::BasicLoco : Address::ExtendedLoco},
+    dlllllll,
+    hhhhhhhh);
 }
 
 /// Make a CV access long form packet for verifying CV
@@ -442,7 +446,9 @@ constexpr auto make_cv_access_long_verify_packet(Address::value_type addr,
                                                  uint32_t cv_addr,
                                                  uint8_t byte = 0u) {
   return make_cv_access_long_verify_packet(
-    {addr, addr <= 127u ? Address::Short : Address::Long}, cv_addr, byte);
+    {addr, addr <= 127u ? Address::BasicLoco : Address::ExtendedLoco},
+    cv_addr,
+    byte);
 }
 
 /// Make a CV access long form packet for writing CV
@@ -474,7 +480,9 @@ constexpr auto make_cv_access_long_write_packet(Address::value_type addr,
                                                 uint32_t cv_addr,
                                                 uint8_t byte) {
   return make_cv_access_long_write_packet(
-    {addr, addr <= 127u ? Address::Short : Address::Long}, cv_addr, byte);
+    {addr, addr <= 127u ? Address::BasicLoco : Address::ExtendedLoco},
+    cv_addr,
+    byte);
 }
 
 /// Make a CV access long form packet for verifying CV bit
@@ -512,7 +520,10 @@ constexpr auto make_cv_access_long_verify_packet(Address::value_type addr,
                                                  bool bit,
                                                  uint32_t pos) {
   return make_cv_access_long_verify_packet(
-    {addr, addr <= 127u ? Address::Short : Address::Long}, cv_addr, bit, pos);
+    {addr, addr <= 127u ? Address::BasicLoco : Address::ExtendedLoco},
+    cv_addr,
+    bit,
+    pos);
 }
 
 /// Make a CV access long form packet for writing CV bit
@@ -550,7 +561,10 @@ constexpr auto make_cv_access_long_write_packet(Address::value_type addr,
                                                 bool bit,
                                                 uint32_t pos) {
   return make_cv_access_long_write_packet(
-    {addr, addr <= 127u ? Address::Short : Address::Long}, cv_addr, bit, pos);
+    {addr, addr <= 127u ? Address::BasicLoco : Address::ExtendedLoco},
+    cv_addr,
+    bit,
+    pos);
 }
 
 /// Make a CV access long form service packet for verifying CV

--- a/tests/address.cpp
+++ b/tests/address.cpp
@@ -1,20 +1,34 @@
 #include <gtest/gtest.h>
 #include <dcc/dcc.hpp>
 
-TEST(address, short_and_long_address_compare_equal_based_solely_on_value) {
-  dcc::Address short_addr{.value = 3u, .type = dcc::Address::Short};
-  dcc::Address long_addr{.value = 3u, .type = dcc::Address::Long};
+TEST(address,
+     basic_and_extended_loco_address_compare_equal_based_solely_on_value) {
+  dcc::Address short_addr{.value = 3u, .type = dcc::Address::BasicLoco};
+  dcc::Address long_addr{.value = 3u, .type = dcc::Address::ExtendedLoco};
   EXPECT_EQ(short_addr, long_addr);
   EXPECT_EQ(short_addr, 3u);
   EXPECT_EQ(long_addr, 3u);
 }
 
-TEST(address, short_and_accessory_address_are_not_equal_despite_same_value) {
-  dcc::Address short_addr{.value = 3u, .type = dcc::Address::Short};
-  dcc::Address accessory_addr{.value = 3u, .type = dcc::Address::Accessory};
-  EXPECT_NE(short_addr, accessory_addr);
+TEST(address,
+     basic_loco_and_basic_accessory_address_are_not_equal_despite_same_value) {
+  dcc::Address short_addr{.value = 3u, .type = dcc::Address::BasicLoco};
+  dcc::Address basic_accessory_addr{.value = 3u,
+                                    .type = dcc::Address::BasicAccessory};
+  EXPECT_NE(short_addr, basic_accessory_addr);
   EXPECT_EQ(short_addr, 3u);
-  EXPECT_EQ(accessory_addr, 3u);
+  EXPECT_EQ(basic_accessory_addr, 3u);
+}
+
+TEST(address,
+     basic_and_extended_accessory_address_are_not_equal_despite_same_value) {
+  dcc::Address basic_accessory_addr{.value = 3u,
+                                    .type = dcc::Address::BasicAccessory};
+  dcc::Address extended_accessory_addr{.value = 3u,
+                                       .type = dcc::Address::ExtendedAccessory};
+  EXPECT_NE(basic_accessory_addr, extended_accessory_addr);
+  EXPECT_EQ(basic_accessory_addr, 3u);
+  EXPECT_EQ(extended_accessory_addr, 3u);
 }
 
 TEST(address, decode_address) {
@@ -27,19 +41,28 @@ TEST(address, decode_address) {
   {
     std::array<uint8_t, 2uz> data{0b0000'0011u};
     EXPECT_EQ(dcc::decode_address(cbegin(data)),
-              (dcc::Address{.value = 3u, .type = dcc::Address::Short}));
+              (dcc::Address{.value = 3u, .type = dcc::Address::BasicLoco}));
   }
 
   {
-    std::array<uint8_t, 2uz> data{0b1011'0011u, 0b0010'0010u};
-    EXPECT_EQ(dcc::decode_address(cbegin(data)),
-              (dcc::Address{.value = 717u, .type = dcc::Address::Accessory}));
+    std::array<uint8_t, 2uz> data{0b1011'0011u, 0b1010'0010u};
+    EXPECT_EQ(
+      dcc::decode_address(cbegin(data)),
+      (dcc::Address{.value = 717u, .type = dcc::Address::BasicAccessory}));
+  }
+
+  {
+    std::array<uint8_t, 2uz> data{0b1011'0011u, 0b0010'0011u};
+    EXPECT_EQ(
+      dcc::decode_address(cbegin(data)),
+      (dcc::Address{.value = 717u, .type = dcc::Address::ExtendedAccessory}));
   }
 
   {
     std::array<uint8_t, 2uz> data{0b1101'0011u, 0b0000'1010u};
-    EXPECT_EQ(dcc::decode_address(cbegin(data)),
-              (dcc::Address{.value = 4874u, .type = dcc::Address::Long}));
+    EXPECT_EQ(
+      dcc::decode_address(cbegin(data)),
+      (dcc::Address{.value = 4874u, .type = dcc::Address::ExtendedLoco}));
   }
 
   {
@@ -68,27 +91,39 @@ TEST(address, encode_address) {
 
   {
     std::array<uint8_t, 2uz> data{};
-    EXPECT_EQ(
-      dcc::encode_address(
-        dcc::Address{.value = 3u, .type = dcc::Address::Short}, begin(data)),
-      cbegin(data) + 1);
+    EXPECT_EQ(dcc::encode_address(
+                dcc::Address{.value = 3u, .type = dcc::Address::BasicLoco},
+                begin(data)),
+              cbegin(data) + 1);
     EXPECT_EQ(data, (decltype(data){0b0000'0011u}));
   }
 
   {
     std::array<uint8_t, 2uz> data{};
-    EXPECT_EQ(dcc::encode_address(
-                dcc::Address{.value = 717u, .type = dcc::Address::Accessory},
-                begin(data)),
-              cbegin(data) + 2);
-    EXPECT_EQ(data, (decltype(data){0b1011'0011u, 0b0010'0010u}));
+    EXPECT_EQ(
+      dcc::encode_address(
+        dcc::Address{.value = 717u, .type = dcc::Address::BasicAccessory},
+        begin(data)),
+      cbegin(data) + 2);
+    EXPECT_EQ(data, (decltype(data){0b1011'0011u, 0b1010'0010u}));
   }
 
   {
     std::array<uint8_t, 2uz> data{};
     EXPECT_EQ(
       dcc::encode_address(
-        dcc::Address{.value = 4874u, .type = dcc::Address::Long}, begin(data)),
+        dcc::Address{.value = 717u, .type = dcc::Address::ExtendedAccessory},
+        begin(data)),
+      cbegin(data) + 2);
+    EXPECT_EQ(data, (decltype(data){0b1011'0011u, 0b0010'0011u}));
+  }
+
+  {
+    std::array<uint8_t, 2uz> data{};
+    EXPECT_EQ(
+      dcc::encode_address(
+        dcc::Address{.value = 4874u, .type = dcc::Address::ExtendedLoco},
+        begin(data)),
       cbegin(data) + 2);
     EXPECT_EQ(data, (decltype(data){0b1101'0011u, 0b0000'1010u}));
   }

--- a/tests/rx/rx_test.hpp
+++ b/tests/rx/rx_test.hpp
@@ -35,9 +35,10 @@ protected:
   }
 
   NiceMock<RxMock> _mock;
-  dcc::Addresses _addrs{.primary = {.value = 3u, .type = dcc::Address::Short},
-                        .consist = {.value = 4u, .type = dcc::Address::Short},
-                        .logon = {.value = 1000u, .type = dcc::Address::Long}};
+  dcc::Addresses _addrs{
+    .primary = {.value = 3u, .type = dcc::Address::BasicLoco},
+    .consist = {.value = 4u, .type = dcc::Address::BasicLoco},
+    .logon = {.value = 1000u, .type = dcc::Address::ExtendedLoco}};
   std::array<uint8_t, smath::pow(2uz, 16uz)> _cvs{};
   uint32_t _did{0xAABBCCDDu};
   uint16_t _cid{0xABCDu};

--- a/tests/rx/write_bit.cpp
+++ b/tests/rx/write_bit.cpp
@@ -1,6 +1,6 @@
 #include "rx_test.hpp"
 
-TEST_F(RxTest, write_bit_operations_mode) {
+TEST_F(RxTest, ignore_write_bit_operations_mode) {
   // Don't write any CV which might trigger config (e.g. 1, 28, ...)!
   auto cv_addr{RandomInterval(30u, smath::pow(2u, 10u) - 1u)};
   auto bit{RandomInterval(0u, 1u)};
@@ -9,7 +9,7 @@ TEST_F(RxTest, write_bit_operations_mode) {
     _addrs.primary, cv_addr, bit, position)};
 
   // 2 or more identical packets
-  EXPECT_CALL(_mock, writeCv(cv_addr, bit, position));
+  EXPECT_CALL(_mock, writeCv(cv_addr, bit, position)).Times(0);
   for (auto i{0uz}; i < 2uz; ++i) {
     Receive(packet);
     Execute();

--- a/tests/tx/capacity.cpp
+++ b/tests/tx/capacity.cpp
@@ -1,0 +1,3 @@
+#include "tx_test.hpp"
+
+TEST_F(TxTest, capacity) { EXPECT_EQ(_mock.capacity(), DCC_TX_DEQUE_SIZE); }

--- a/tests/tx/size.cpp
+++ b/tests/tx/size.cpp
@@ -1,0 +1,7 @@
+#include "tx_test.hpp"
+
+TEST_F(TxTest, size) {
+  EXPECT_EQ(_mock.size(), 0uz);
+  _mock.packet({});
+  EXPECT_EQ(_mock.size(), 1uz);
+}

--- a/tests/tx/tx_mock.hpp
+++ b/tests/tx/tx_mock.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <dcc/dcc.hpp>
+
+struct TxMock : dcc::tx::CrtpBase<TxMock> {
+  MOCK_METHOD(void, trackOutputs, (bool, bool));
+  MOCK_METHOD(void, biDiStart, ());
+  MOCK_METHOD(void, biDiChannel1, ());
+  MOCK_METHOD(void, biDiChannel2, ());
+  MOCK_METHOD(void, biDiEnd, ());
+};

--- a/tests/tx/tx_test.cpp
+++ b/tests/tx/tx_test.cpp
@@ -1,0 +1,5 @@
+#include "tx_test.hpp"
+
+TxTest::TxTest() {}
+
+TxTest::~TxTest() {}

--- a/tests/tx/tx_test.hpp
+++ b/tests/tx/tx_test.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include "tx_mock.hpp"
+
+using namespace ::testing;
+
+// Transmit test fixture
+struct TxTest : ::testing::Test {
+protected:
+  TxTest();
+  virtual ~TxTest();
+
+  NiceMock<TxMock> _mock;
+};


### PR DESCRIPTION
- Add `size` and `capacity` methods to `tx::CrtpBase`
- Remove async CV bit operations
- Async CV operations are only used in service mode
- Add `BasicAccessory` and `ExtendedAccessory` address
- Rename `Short` to `BasicLoco` address
- Rename `Long` to `ExtendedLoco` address