### PR TITLE
feat: add boolean return value to `bytes` and `packet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.40.1
+- Add boolean return value to `bytes` and `packet` methods of `tx::CrtpBase`
+
 ## 0.40.0
 - Add `size` and `capacity` methods to `tx::CrtpBase`
 - Remove async CV bit operations

--- a/include/dcc/tx/crtp_base.hpp
+++ b/include/dcc/tx/crtp_base.hpp
@@ -43,17 +43,22 @@ struct CrtpBase {
   /// Transmit packet
   ///
   /// \param  packet  Packet
-  void packet(Packet const& packet) {
+  /// \retval true    Packet added to deque
+  /// \retval false   Packet not added to deque
+  bool packet(Packet const& packet) {
     return bytes({cbegin(packet), std::size(packet)});
   }
 
   /// Transmit bytes
   ///
   /// \param  bytes Bytes containing DCC packet
-  void bytes(std::span<uint8_t const> bytes) {
-    if (full(_deque)) return;
+  /// \retval true  Bytes added to deque
+  /// \retval false Bytes not added to deque
+  bool bytes(std::span<uint8_t const> bytes) {
+    if (full(_deque)) return false;
     assert(std::size(bytes) <= DCC_MAX_PACKET_SIZE);
     _deque.push_back(bytes2timings(bytes, _cfg));
+    return true;
   }
 
   /// Get next bit duration to transmit in µs

--- a/tests/tx/bytes.cpp
+++ b/tests/tx/bytes.cpp
@@ -1,0 +1,6 @@
+#include "tx_test.hpp"
+
+TEST_F(TxTest, bytes) {
+  for (auto i{DCC_TX_DEQUE_SIZE}; i-- > 0uz;) EXPECT_TRUE(_mock.bytes({}));
+  EXPECT_FALSE(_mock.bytes({}));
+}

--- a/tests/tx/packet.cpp
+++ b/tests/tx/packet.cpp
@@ -1,0 +1,6 @@
+#include "tx_test.hpp"
+
+TEST_F(TxTest, packet) {
+  for (auto i{DCC_TX_DEQUE_SIZE}; i-- > 0uz;) EXPECT_TRUE(_mock.packet({}));
+  EXPECT_FALSE(_mock.packet({}));
+}


### PR DESCRIPTION
Adds a boolean return value to `bytes` and `packet` methods of `tx::CrtpBase`. Those allow checking if the passed in data got added to the deque.