### PR TITLE
feat: alternative on-the-fly timing calculation for tx::Base

### DIFF
--- a/include/dcc/tx/ipacket.hpp
+++ b/include/dcc/tx/ipacket.hpp
@@ -1,0 +1,135 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// Indexed Packet buffer
+///
+/// \file   dcc/tx/ipacket.hpp
+/// \author Jonas Gahlert
+/// \date   19.03.2025
+
+#pragma once
+
+#include "../packet.hpp"
+#include "config.hpp"
+#include "timing.hpp"
+
+#include <algorithm>
+
+namespace dcc::tx {
+
+/// Indexed \ref dcc::Packet "Packet" buffer, used for on-the-fly DCC timing
+/// calculation.
+///
+/// \details
+/// Packet is indexed and timings are returned half-bit-wise. The packet can be
+/// cecked for remaining data with a call to \ref IPacket::hasNext "hasNext" and
+/// a call to \ref IPacket::next "next" yields the next timing.
+///
+/// In case this is an idle-packet, the index packet can be reset with \ref
+/// IPacket::resetIndex "resetIndex" and a new \ref dcc::tx::Config "Config" can
+/// be loaded using \ref IPacket::recalculate "recalculate".
+///
+/// \warning
+/// The Packet will assert an out-of-bounds state. Usage of \ref
+/// IPacket::hasNext "hasNext" before calling \ref IPacket::next "next" is
+/// strongly recommended.
+struct IPacket {
+  /// CTor - Packet copy
+  ///
+  /// \param p    Packet
+  /// \param cfg  Config
+  IPacket(Packet const& p, Config cfg = {}) : _packet{p}, _cfg{cfg} {}
+
+  /// CTor - Byte span
+  ///
+  /// \param b    Bytes
+  /// \param cfg  Config
+  IPacket(std::span<uint8_t const> b, Config cfg = {}) : _cfg{cfg} {
+    _packet.clear();
+    std::copy(b.begin(), b.end(), std::back_inserter(_packet));
+  }
+
+  /// CTor - Idle Packet
+  ///
+  /// \param cfg  Config
+  IPacket(Config cfg = {}) : _packet{make_idle_packet()}, _cfg{cfg} {}
+
+  /// Next timing
+  ///
+  /// \return Next timing
+  uint16_t next() {
+    // Check that packet isn't out of bounds
+    assert(_packet_index <= _packet.size());
+
+    bool bit = false;
+    if (_preamble_index < _cfg.num_preamble) {
+      // Preamble
+      bit = true;
+      if (_half) _preamble_index++;
+
+    } else {
+      // Packet
+      if (_packet_index < _packet.size()) {
+        // Byte
+        bit = (_packet[_packet_index] & (1 << _byte_index)) > 0;
+        if (_half) {
+          _byte_index--;
+          if (_byte_index == static_cast<Packet::size_type>(-1)) {
+            _packet_index++;
+            _byte_index = 8;
+          }
+        }
+      } else {
+        // Stop bit
+        bit = true;
+        if (_half) _packet_index++;
+      }
+    }
+    // Result
+    _half = !_half;
+    return (bit) ? _cfg.bit1_duration : _cfg.bit0_duration;
+  }
+
+  /// Has next
+  ///
+  /// \retval true  Has next
+  /// \retval false Packet done
+  bool hasNext() const { return (_packet.size() + 1) > _packet_index; }
+
+  /// Reset index
+  ///
+  /// \note Intended for use with idle packet only
+  void resetIndex() {
+    _preamble_index = _packet_index = 0;
+    _byte_index = 8;
+  }
+
+  /// Recalculate
+  ///
+  /// \note Intended for use with idle packet only
+  ///
+  /// \param cfg Config
+  void recalculate(Config cfg = {}) { _cfg = cfg; }
+
+private:
+  /// Packet
+  Packet _packet{0};
+
+  /// Half bit indicator
+  bool _half{false};
+
+  /// Preamble index
+  Packet::size_type _preamble_index{0};
+
+  /// Packet index
+  Packet::size_type _packet_index{0};
+
+  /// Byte index
+  Packet::size_type _byte_index{8};
+
+  /// Config
+  Config _cfg;
+};
+
+} // namespace dcc::tx

--- a/include/dcc/tx/itimings.hpp
+++ b/include/dcc/tx/itimings.hpp
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// Indexed Timings buffer
+///
+/// \file   dcc/tx/itimings.hpp
+/// \author Jonas Gahlert
+/// \date   19.03.2025
+
+#pragma once
+
+#include <ztl/inplace_vector.hpp>
+#include "../packet.hpp"
+#include "config.hpp"
+#include "timings.hpp"
+
+namespace dcc::tx {
+
+/// Indexed \ref dcc::tx::Timings "Timings" buffer, used for on-the-fly DCC
+/// timing calculation.
+///
+/// \details
+/// Packet is indexed and timings are returned half-bit-wise. The packet can be
+/// cecked for remaining data with a call to \ref ITimings::hasNext "hasNext"
+/// and a call to \ref ITimings::next "next" yields the next timing.
+///
+/// In case this is an idle-packet, the index packet can be reset with \ref
+/// ITimings::resetIndex "resetIndex" and a new \ref dcc::tx::Config "Config"
+/// can be loaded using \ref ITimings::recalculate "recalculate".
+///
+/// \warning
+/// The Packet will assert an out-of-bounds state. Usage of \ref
+/// ITimings::hasNext "hasNext" before calling \ref ITimings::next "next" is
+/// strongly recommended.
+struct ITimings {
+  /// CTor - Packet copy
+  ///
+  /// \param p    Packet
+  /// \param cfg  Config
+  ITimings(Packet const& p, Config cfg = {})
+    : _timings{packet2timings(p, cfg)} {}
+
+  /// CTor - Byte span
+  ///
+  /// \param b    Bytes
+  /// \param cfg  Config
+  ITimings(std::span<uint8_t const> b, Config cfg = {})
+    : _timings{bytes2timings(b, cfg)} {}
+
+  /// CTor - Idle Packet
+  ///
+  /// \param cfg  Config
+  ITimings(Config cfg = {})
+    : _timings{bytes2timings(make_idle_packet(), cfg)} {}
+
+  /// Next timing
+  ///
+  /// \return Next timing
+  Timings::value_type next() {
+    // Check that packet isn't out of bounds
+    assert(_packet_index < _timings.size());
+
+    return _timings[static_cast<Timings::size_type>(_packet_index++)];
+  }
+
+  /// Has next
+  ///
+  /// \retval true  Has next
+  /// \retval false Packet done
+  bool hasNext() const { return _packet_index < _timings.size(); }
+
+  /// Reset index
+  ///
+  /// \note Intended for use with idle packet only
+  void resetIndex() { _packet_index = 0; }
+
+  /// Recalculate
+  ///
+  /// \note Intended for use with idle packet only
+  ///
+  /// \param cfg Config
+  void recalculate(Config cfg = {}) {
+    _timings = packet2timings(make_idle_packet(), cfg);
+  }
+
+private:
+  /// Timings
+  Timings _timings;
+
+  /// Packet index
+  size_t _packet_index{0};
+};
+
+} // namespace dcc::tx

--- a/include/dcc/tx/pre_cutout.hpp
+++ b/include/dcc/tx/pre_cutout.hpp
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// Track outputs
+///
+/// \file   dcc/tx/pre_cutout.hpp
+/// \author Jonas Gahlert
+/// \date   19/03/2025
+
+#pragma once
+
+#include <concepts>
+
+namespace dcc::tx {
+
+template<typename T>
+concept PreCutout = requires(T t) {
+  { t.preCutout() } -> std::same_as<void>;
+};
+
+} // namespace dcc::tx

--- a/tests/tx/timings.cpp
+++ b/tests/tx/timings.cpp
@@ -1,0 +1,80 @@
+#include "dcc/dcc.hpp"
+#include "tx_test.hpp"
+
+TEST_F(TxTest, bytes2timings_preamble) {
+  uint8_t byte = 0xC3u;
+  auto tim = dcc::tx::bytes2timings(std::span<uint8_t>(&byte, 1u));
+
+  uint16_t offset = 0;
+
+  EvalPreamble(tim, offset);
+}
+
+TEST_F(TxTest, byte2timings_start_bit) {
+  uint8_t byte = 0xC3u;
+  auto tim = dcc::tx::bytes2timings(std::span<uint8_t>(&byte, 1u));
+
+  uint16_t offset = 2 * DCC_TX_MIN_PREAMBLE_BITS;
+
+  EvalStartBit(tim, offset);
+}
+
+TEST_F(TxTest, bytes2timings_byte) {
+  uint8_t byte = 0xC3u;
+  auto tim = dcc::tx::bytes2timings(std::span<uint8_t>(&byte, 1u));
+
+  uint16_t offset = 2 * DCC_TX_MIN_PREAMBLE_BITS + 2;
+
+  EvalByte(tim, byte, offset);
+}
+TEST_F(TxTest, bytes2timings_stop_bit) {
+  uint8_t byte = 0xC3u;
+  auto tim = dcc::tx::bytes2timings(std::span<uint8_t>(&byte, 1u));
+
+  uint16_t offset = 2 * DCC_TX_MIN_PREAMBLE_BITS + 2 + 2 * 8;
+
+  EvalStopBit(tim, offset);
+}
+
+TEST_F(TxTest, bytes2timings_timings_size) {
+  uint8_t byte = 0xC3u;
+  auto tim = dcc::tx::bytes2timings(std::span<uint8_t>(&byte, 1u));
+
+  ASSERT_EQ(tim.size(), 2 * (DCC_TX_MIN_PREAMBLE_BITS + 1 + 8 + 1));
+}
+
+TEST_F(TxTest, bytes2timings_multiple_bytes) {
+  std::array<uint8_t, 3> bytes = {0xC3u, 0xC3u, 0xC3u};
+  auto tim = dcc::tx::bytes2timings(bytes);
+
+  uint16_t offset = 2 * DCC_TX_MIN_PREAMBLE_BITS;
+
+  for (uint16_t i = 0; i < 3; i++) {
+    EvalStartBit(tim, offset);
+    EvalByte(tim, bytes[i], offset);
+  }
+  EvalStopBit(tim, offset);
+}
+
+TEST_F(TxTest, bytes2timings_cfg_timings) {
+  uint8_t byte = 0xC3u;
+  dcc::tx::Config cfg{};
+  cfg.bit0_duration = dcc::tx::Timing::Bit0Max;
+  cfg.bit1_duration = dcc::tx::Timing::Bit1Max;
+  auto tim = dcc::tx::bytes2timings(std::span<uint8_t>(&byte, 1u), cfg);
+
+  uint16_t offset = 2 * DCC_TX_MIN_PREAMBLE_BITS + 2;
+
+  EvalByte(tim, byte, offset, cfg);
+}
+
+TEST_F(TxTest, bytes2timings_cfg_preamble) {
+  uint8_t byte = 0xC3u;
+  dcc::tx::Config cfg{};
+  cfg.num_preamble = DCC_TX_MIN_PREAMBLE_BITS + 2;
+  auto tim = dcc::tx::bytes2timings(std::span<uint8_t>(&byte, 1u), cfg);
+
+  uint16_t offset = 0;
+
+  EvalPreamble(tim, offset, cfg);
+}

--- a/tests/tx/transmit_p.cpp
+++ b/tests/tx/transmit_p.cpp
@@ -1,0 +1,194 @@
+#include "tx_test.hpp"
+
+TEST_F(TxTest, transmit_p_preamble) {
+  auto res = TransmitP(3u);
+  dcc::tx::Timings::size_type offset = 0;
+  ASSERT_TRUE(EvalPreamble(res, offset)) << "Malformed Preamble at " << offset;
+}
+
+TEST_F(TxTest, transmit_p_bytes) {
+  dcc::Packet pkt{0xC3u, 0xC3u, 0xC3u};
+  _mockp.packet(pkt);
+
+  TransmitP(3u); // Skip idle
+  auto res = TransmitP(3u);
+  dcc::tx::Timings::size_type offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, pkt, offset))
+    << "Malformed Packet data at " << offset;
+}
+
+TEST_F(TxTest, transmit_p_bidi) {
+
+  auto res = TransmitP(3u);
+  uint16_t offset = 2 * DCC_TX_MIN_PREAMBLE_BITS // Preamble
+                    + 3 * 2 * 9                  // 3 Byte
+                    + 2;                         // Stop-Bit
+
+  ASSERT_TRUE(EvalBiDi(res, offset)) << "Malformed  BiDi timings at " << offset;
+}
+
+TEST_F(TxTest, transmit_p_cfg_preamble) {
+  dcc::tx::Config cfg{};
+  cfg.num_preamble = 19;
+  _mockp.init(cfg);
+
+  dcc::Packet pkt{0xC3u, 0xC3u, 0xC3u};
+  _mockp.packet(pkt);
+
+  // Idle
+  auto res = TransmitP(3u, cfg);
+
+  dcc::tx::Timings::size_type offset = 0;
+
+  ASSERT_TRUE(EvalPreamble(res, offset, cfg))
+    << "Malformed  Preamble at " << offset;
+
+  // Packet
+  res = TransmitP(3u, cfg);
+
+  offset = 0;
+
+  ASSERT_TRUE(EvalPreamble(res, offset, cfg))
+    << "Malformed  Preamble at " << offset;
+}
+
+TEST_F(TxTest, transmit_p_cfg_bytes) {
+  dcc::tx::Config cfg{};
+  cfg.bit0_duration = dcc::tx::Timing::Bit0Max;
+  cfg.bit1_duration = dcc::tx::Timing::Bit1Max;
+  _mockp.init(cfg);
+
+  dcc::Packet pkt{0xC3u, 0xC3u, 0xC3u};
+  _mockp.packet(pkt);
+
+  // Idle
+  auto res = TransmitP(3u, cfg);
+
+  dcc::tx::Timings::size_type offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, dcc::make_idle_packet(), offset, cfg))
+    << "Malformed Timings data at " << offset;
+  ;
+
+  // Packet
+  res = TransmitP(3u, cfg);
+
+  offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, pkt, offset, cfg))
+    << "Malformed Timings data at " << offset;
+  ;
+}
+
+TEST_F(TxTest, transmit_p_cfg_no_bidi) {
+  dcc::tx::Config cfg{};
+  cfg.flags.bidi = false;
+  _mockp.init(cfg);
+
+  auto pkt = dcc::make_idle_packet();
+
+  // Idle
+  auto res = TransmitP(3u, cfg);
+
+  dcc::tx::Timings::size_type offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, pkt, offset, cfg))
+    << "Malformed Packet data at " << offset;
+
+  // Packet
+  res = TransmitP(3u, cfg);
+
+  offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, pkt, offset, cfg))
+    << "Malformed second Packet data at " << offset;
+}
+
+TEST_F(TxTest, transmit_p_idle) {
+
+  auto res = TransmitP(3u);
+
+  auto pkt = dcc::make_idle_packet();
+  dcc::tx::Timings::size_type offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, pkt, offset))
+    << "Malformed Idle Packet data at " << offset;
+}
+
+TEST_F(TxTest, transmit_p_paket_after_idle) {
+  dcc::Packet pkt{0xC3u, 0xC3u, 0xC3u};
+  _mockp.packet(pkt);
+
+  auto i_pkt = dcc::make_idle_packet();
+
+  auto res = TransmitP(3u);
+
+  dcc::tx::Timings::size_type offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, i_pkt, offset))
+    << "Malformed Idle Packet data at " << offset;
+
+  offset = 0;
+  res = TransmitP(3u);
+
+  ASSERT_TRUE(EvalPacket(res, pkt, offset))
+    << "Malformed Packet data at " << offset;
+}
+
+TEST_F(TxTest, transmit_p_idle_after_paket) {
+  dcc::Packet pkt{0xC3u, 0xC3u, 0xC3u};
+  _mockp.packet(pkt);
+
+  auto i_pkt = dcc::make_idle_packet();
+
+  TransmitP(3u);
+  auto res = TransmitP(3u);
+
+  dcc::tx::Timings::size_type offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, pkt, offset))
+    << "Malformed Packet data at " << offset;
+
+  offset = 0;
+  res = TransmitP(3u);
+
+  ASSERT_TRUE(EvalPacket(res, i_pkt, offset))
+    << "Malformed Packet data at " << offset;
+}
+
+TEST_F(TxTest, transmit_p_packet_after_packet) {
+  dcc::Packet pkt{0xC3u, 0xC3u, 0xC3u};
+  _mockp.packet(pkt);
+  _mockp.packet(pkt);
+
+  TransmitP(3u);
+  auto res = TransmitP(3u);
+
+  uint16_t offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, pkt, offset))
+    << "Malformed Packet data at " << offset;
+
+  offset = 0;
+  res = TransmitP(3u);
+
+  ASSERT_TRUE(EvalPacket(res, pkt, offset))
+    << "Malformed Packet data at " << offset;
+}
+
+TEST_F(TxTest, transmit_p_keep_idle) {
+  auto i_pkt = dcc::make_idle_packet();
+
+  auto res = TransmitP(3u);
+
+  uint16_t offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, i_pkt, offset))
+    << "Malformed Idle Packet data at " << offset;
+
+  offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, i_pkt, offset))
+    << "Malformed Idle Packet data at " << offset;
+}

--- a/tests/tx/transmit_t.cpp
+++ b/tests/tx/transmit_t.cpp
@@ -1,0 +1,193 @@
+#include "tx_test.hpp"
+
+TEST_F(TxTest, transmit_t_preamble) {
+  auto res = TransmitT(3u);
+  dcc::tx::Timings::size_type offset = 0;
+  ASSERT_TRUE(EvalPreamble(res, offset)) << "Malformed Preamble at " << offset;
+}
+
+TEST_F(TxTest, transmit_t_bytes) {
+  dcc::Packet pkt{0xC3u, 0xC3u, 0xC3u};
+  _mock.packet(pkt);
+
+  TransmitT(3u); // Skip idle
+  auto res = TransmitT(3u);
+  dcc::tx::Timings::size_type offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, pkt, offset))
+    << "Malformed Packet data at " << offset;
+}
+
+TEST_F(TxTest, transmit_t_bidi) {
+
+  auto res = TransmitT(3u);
+  uint16_t offset = 2 * DCC_TX_MIN_PREAMBLE_BITS // Preamble
+                    + 3 * 2 * 9                  // 3 Byte
+                    + 2;                         // Stop-Bit
+
+  ASSERT_TRUE(EvalBiDi(res, offset)) << "Malformed  BiDi timings at " << offset;
+}
+
+TEST_F(TxTest, transmit_t_cfg_preamble) {
+  dcc::tx::Config cfg{};
+  cfg.num_preamble = 19;
+  _mock.init(cfg);
+
+  dcc::Packet pkt{0xC3u, 0xC3u, 0xC3u};
+  _mock.packet(pkt);
+
+  // Idle
+  auto res = TransmitT(3u, cfg);
+
+  dcc::tx::Timings::size_type offset = 0;
+
+  ASSERT_TRUE(EvalPreamble(res, offset, cfg))
+    << "Malformed  Preamble at " << offset;
+
+  // Packet
+  res = TransmitT(3u, cfg);
+
+  offset = 0;
+
+  ASSERT_TRUE(EvalPreamble(res, offset, cfg))
+    << "Malformed  Preamble at " << offset;
+}
+
+TEST_F(TxTest, transmit_t_cfg_bytes) {
+  dcc::tx::Config cfg{};
+  cfg.bit0_duration = dcc::tx::Timing::Bit0Max;
+  cfg.bit1_duration = dcc::tx::Timing::Bit1Max;
+  _mock.init(cfg);
+
+  dcc::Packet pkt{0xC3u, 0xC3u, 0xC3u};
+  _mock.packet(pkt);
+
+  // Idle
+  auto res = TransmitT(3u, cfg);
+
+  dcc::tx::Timings::size_type offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, dcc::make_idle_packet(), offset, cfg))
+    << "Malformed Timings data at " << offset;
+
+  // Packet
+  res = TransmitT(3u, cfg);
+
+  offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, pkt, offset, cfg))
+    << "Malformed Timings data at " << offset;
+  ;
+}
+
+TEST_F(TxTest, transmit_t_cfg_no_bidi) {
+  dcc::tx::Config cfg{};
+  cfg.flags.bidi = false;
+  _mock.init(cfg);
+
+  auto pkt = dcc::make_idle_packet();
+
+  auto res = TransmitT(3u, cfg);
+
+  // Idle
+  dcc::tx::Timings::size_type offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, pkt, offset, cfg))
+    << "Malformed Packet data at " << offset;
+
+  // Packet
+  res = TransmitT(3u, cfg);
+
+  offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, pkt, offset, cfg))
+    << "Malformed second Packet data at " << offset;
+}
+
+TEST_F(TxTest, transmit_t_idle) {
+
+  auto res = TransmitT(3u);
+
+  auto pkt = dcc::make_idle_packet();
+  dcc::tx::Timings::size_type offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, pkt, offset))
+    << "Malformed Idle Packet data at " << offset;
+}
+
+TEST_F(TxTest, transmit_t_paket_after_idle) {
+  dcc::Packet pkt{0xC3u, 0xC3u, 0xC3u};
+  _mock.packet(pkt);
+
+  auto i_pkt = dcc::make_idle_packet();
+
+  auto res = TransmitT(3u);
+
+  dcc::tx::Timings::size_type offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, i_pkt, offset))
+    << "Malformed Idle Packet data at " << offset;
+
+  offset = 0;
+  res = TransmitT(3u);
+
+  ASSERT_TRUE(EvalPacket(res, pkt, offset))
+    << "Malformed Packet data at " << offset;
+}
+
+TEST_F(TxTest, transmit_t_idle_after_paket) {
+  dcc::Packet pkt{0xC3u, 0xC3u, 0xC3u};
+  _mock.packet(pkt);
+
+  auto i_pkt = dcc::make_idle_packet();
+
+  TransmitT(3u);
+  auto res = TransmitT(3u);
+
+  dcc::tx::Timings::size_type offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, pkt, offset))
+    << "Malformed Packet data at " << offset;
+
+  offset = 0;
+  res = TransmitT(3u);
+
+  ASSERT_TRUE(EvalPacket(res, i_pkt, offset))
+    << "Malformed Packet data at " << offset;
+}
+
+TEST_F(TxTest, transmit_t_packet_after_packet) {
+  dcc::Packet pkt{0xC3u, 0xC3u, 0xC3u};
+  _mock.packet(pkt);
+  _mock.packet(pkt);
+
+  TransmitT(3u);
+  auto res = TransmitT(3u);
+
+  uint16_t offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, pkt, offset))
+    << "Malformed Packet data at " << offset;
+
+  offset = 0;
+  res = TransmitT(3u);
+
+  ASSERT_TRUE(EvalPacket(res, pkt, offset))
+    << "Malformed Packet data at " << offset;
+}
+
+TEST_F(TxTest, transmit_t_keep_idle) {
+  auto i_pkt = dcc::make_idle_packet();
+
+  auto res = TransmitT(3u);
+
+  uint16_t offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, i_pkt, offset))
+    << "Malformed Idle Packet data at " << offset;
+
+  offset = 0;
+
+  ASSERT_TRUE(EvalPacket(res, i_pkt, offset))
+    << "Malformed Idle Packet data at " << offset;
+}

--- a/tests/tx/tx_mock.hpp
+++ b/tests/tx/tx_mock.hpp
@@ -4,7 +4,14 @@
 #include <gtest/gtest.h>
 #include <dcc/dcc.hpp>
 
-struct TxMock : dcc::tx::CrtpBase<TxMock> {
+struct TxMock : dcc::tx::CrtpBase<TxMock, dcc::tx::ITimings> {
+  MOCK_METHOD(void, biDiStart, ());
+  MOCK_METHOD(void, biDiChannel1, ());
+  MOCK_METHOD(void, biDiChannel2, ());
+  MOCK_METHOD(void, biDiEnd, ());
+};
+
+struct TxMockP : dcc::tx::CrtpBase<TxMockP, dcc::tx::IPacket> {
   MOCK_METHOD(void, biDiStart, ());
   MOCK_METHOD(void, biDiChannel1, ());
   MOCK_METHOD(void, biDiChannel2, ());

--- a/tests/tx/tx_test.cpp
+++ b/tests/tx/tx_test.cpp
@@ -1,5 +1,172 @@
 #include "tx_test.hpp"
 
+bool TxTest::EvalPacket(dcc::tx::Timings timings,
+                        dcc::Packet packet,
+                        dcc::tx::Timings::size_type& offset,
+                        dcc::tx::Config cfg) {
+  if (!EvalPreamble(timings, offset, cfg)) return false;
+
+  for (dcc::Packet::size_type i = 0; i < packet.size(); i++) {
+    if (!EvalStartBit(timings, offset, cfg)) return false;
+    if (!EvalByte(timings, packet[i], offset, cfg)) return false;
+  }
+  if (!EvalStopBit(timings, offset, cfg)) return false;
+  if (!EvalBiDi(timings, offset, cfg)) return false;
+  return true;
+}
+
+bool TxTest::EvalPreamble(dcc::tx::Timings timings,
+                          dcc::tx::Timings::size_type& offset,
+                          dcc::tx::Config cfg) {
+
+  // Evaluate Preamble
+  for (dcc::tx::Timings::size_type i = 0; i < cfg.num_preamble; i++) {
+    if (timings[static_cast<dcc::tx::Timings::size_type>(2 * i)] !=
+        timings[static_cast<dcc::tx::Timings::size_type>(2 * i + 1)])
+      return false;
+    if (timings[static_cast<dcc::tx::Timings::size_type>(2 * i)] !=
+        cfg.bit1_duration)
+      return false;
+    offset += 2;
+  }
+
+  // Check start bit
+  if (timings[static_cast<dcc::tx::Timings::size_type>(2 * cfg.num_preamble +
+                                                       1)] == cfg.bit1_duration)
+    return false;
+
+  return true;
+}
+
+bool TxTest::EvalByte(dcc::tx::Timings timings,
+                      dcc::Packet::value_type byte,
+                      dcc::tx::Timings::size_type& offset,
+                      dcc::tx::Config cfg) {
+  uint8_t eval = 0u;
+  bool res{true};
+
+  for ([[maybe_unused]] int i = 7; i > -1; i--) {
+    // Half-bits equal
+    if (timings[static_cast<dcc::tx::Timings::size_type>(offset)] !=
+        timings[static_cast<dcc::tx::Timings::size_type>(offset + 1)]) {
+      res = false;
+      break;
+    }
+
+    // Half-bits timing
+    if (!((timings[static_cast<dcc::tx::Timings::size_type>(offset)] ==
+           cfg.bit0_duration) ||
+          (timings[static_cast<dcc::tx::Timings::size_type>(offset)] ==
+           cfg.bit1_duration))) {
+      res = false;
+      break;
+    }
+
+    // Convert bit-halfs to bit
+    if (timings[static_cast<dcc::tx::Timings::size_type>(offset)] ==
+        cfg.bit1_duration)
+      eval |= static_cast<uint8_t>(1u << i);
+
+    offset += 2;
+  }
+
+  if (byte != eval) res = false;
+
+  return res;
+}
+
+bool TxTest::EvalStartBit(dcc::tx::Timings timings,
+                          dcc::tx::Timings::size_type& offset,
+                          dcc::tx::Config cfg) {
+
+  if ((timings[offset] != cfg.bit0_duration) ||
+      (timings[offset + 1] != cfg.bit0_duration))
+    return false;
+  offset += 2;
+  return true;
+}
+
+bool TxTest::EvalStopBit(dcc::tx::Timings timings,
+                         dcc::tx::Timings::size_type& offset,
+                         dcc::tx::Config cfg) {
+  if ((timings[offset] != cfg.bit1_duration) ||
+      (timings[offset + 1] != cfg.bit1_duration))
+    return false;
+  offset += 2;
+  return true;
+}
+
+bool TxTest::EvalBiDi(dcc::tx::Timings timings,
+                      dcc::tx::Timings::size_type& offset,
+                      dcc::tx::Config cfg) {
+
+  if (!cfg.flags.bidi) return true;
+
+  std::array<uint16_t, 5> bidi{
+    dcc::bidi::Timing::TCS,
+    dcc::bidi::Timing::TTS1 - dcc::bidi::Timing::TCS,
+    dcc::bidi::Timing::TTS2 - dcc::bidi::Timing::TTS1,
+    dcc::bidi::Timing::TTC2 - dcc::bidi::Timing::TTS2,
+    dcc::bidi::Timing::TCE - dcc::bidi::Timing::TTC2};
+
+  for (uint16_t i = 0; i < bidi.size(); i++) {
+    if (timings[offset++] != bidi[i]) return false;
+  }
+  return true;
+}
+
+dcc::tx::Timings TxTest::TransmitT(int lengthOfData, dcc::tx::Config cfg) {
+  dcc::tx::Timings res{};
+
+  // Preamble
+  for (int i = 0; i < 2 * static_cast<int>(cfg.num_preamble); i++) {
+    res.push_back(_mock.transmit());
+  }
+
+  // Data
+  for (int i = 0; i < lengthOfData; i++) {
+    for ([[maybe_unused]] int j = 0; j < 2 * 9; j++) {
+      res.push_back(_mock.transmit());
+    }
+  }
+
+  // Stop-Bit
+  res.push_back(_mock.transmit());
+  res.push_back(_mock.transmit());
+
+  // BiDi
+  if (cfg.flags.bidi)
+    for (int i = 0; i < 5; i++) { res.push_back(_mock.transmit()); }
+
+  return res;
+}
+
+dcc::tx::Timings TxTest::TransmitP(int lengthOfData, dcc::tx::Config cfg) {
+  dcc::tx::Timings res{};
+
+  // Preamble
+  for (int i = 0; i < 2 * static_cast<int>(cfg.num_preamble); i++) {
+    res.push_back(_mockp.transmit());
+  }
+
+  // Data
+  for (int i = 0; i < lengthOfData; i++) {
+    for ([[maybe_unused]] int j = 0; j < 2 * 9; j++) {
+      res.push_back(_mockp.transmit());
+    }
+  }
+
+  // Stop-Bit
+  res.push_back(_mockp.transmit());
+  res.push_back(_mockp.transmit());
+
+  // BiDi
+  if (cfg.flags.bidi)
+    for (int i = 0; i < 5; i++) { res.push_back(_mockp.transmit()); }
+
+  return res;
+}
+
 TxTest::TxTest() {}
 
 TxTest::~TxTest() {}

--- a/tests/tx/tx_test.hpp
+++ b/tests/tx/tx_test.hpp
@@ -7,9 +7,36 @@ using namespace ::testing;
 
 // Transmit test fixture
 struct TxTest : ::testing::Test {
+public:
+  bool EvalPacket(dcc::tx::Timings timings,
+                  dcc::Packet packet,
+                  dcc::tx::Timings::size_type& offset,
+                  dcc::tx::Config cfg = {});
+  bool EvalPreamble(dcc::tx::Timings timings,
+                    dcc::tx::Timings::size_type& offset,
+                    dcc::tx::Config cfg = {});
+  bool EvalByte(dcc::tx::Timings timings,
+                uint8_t byte,
+                dcc::tx::Timings::size_type& offset,
+                dcc::tx::Config cfg = {});
+  bool EvalStartBit(dcc::tx::Timings timings,
+                    dcc::tx::Timings::size_type& offset,
+                    dcc::tx::Config cfg = {});
+
+  bool EvalStopBit(dcc::tx::Timings timings,
+                   dcc::tx::Timings::size_type& offset,
+                   dcc::tx::Config cfg = {});
+  bool EvalBiDi(dcc::tx::Timings timings,
+                dcc::tx::Timings::size_type& offset,
+                dcc::tx::Config cfg = {});
+
+  dcc::tx::Timings TransmitT(int lengthOfData, dcc::tx::Config cfg = {});
+  dcc::tx::Timings TransmitP(int lengthOfData, dcc::tx::Config cfg = {});
+
 protected:
   TxTest();
   virtual ~TxTest();
 
   NiceMock<TxMock> _mock;
+  NiceMock<TxMockP> _mockp;
 };


### PR DESCRIPTION
This PR is made with the assumption, that the static_math lib was responsible for the cmake4.x problems. Since this was removed in master, the problem should vanish after merge