### PR TITLE
Block `rx::CrtpBase::biDiChannel1` and `rx::CrtpBase::biDiChannel2` outside of BiDi cutout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+##
+- Block `rx::CrtpBase::biDiChannel1` and `rx::CrtpBase::biDiChannel2` outside of BiDi cutout ([#110](https://github.com/ZIMO-Elektronik/DCC/issues/110))
+
 ## 0.44.5
 - Bugfix `make_logon_assign_packet` ([#102](https://github.com/ZIMO-Elektronik/DCC/issues/102))
 - Bugfix PoM queue not cleared on new CV access packet ([#105](https://github.com/ZIMO-Elektronik/DCC/issues/105))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 FetchContent_Declare(
   CMakeModules
   GIT_REPOSITORY "https://github.com/ZIMO-Elektronik/CMakeModules"
-  GIT_TAG v0.9.5
+  GIT_TAG v0.10.0
   SOURCE_DIR ${CMAKE_BINARY_DIR}/CMakeModules)
 FetchContent_MakeAvailable(CMakeModules)
 
@@ -59,7 +59,7 @@ set(DCC_RX_LOGON_ADDRESS_CV_ADDRESS
     CACHE STRING "First CV address of last logon address")
 set(DCC_RX_MIN_PREAMBLE_BITS
     10u
-    CACHE STRING "Minimum number of preambel bits of decoder")
+    CACHE STRING "Minimum number of preamble bits of decoder")
 set(DCC_RX_MIN_BIT_1_TIMING
     52u
     CACHE STRING "Minimum duration of a 1 bit of decoder")
@@ -80,10 +80,10 @@ set(DCC_RX_BIDI_DEQUE_SIZE
     CACHE STRING "Size of the sender deque of decoder")
 set(DCC_TX_MIN_PREAMBLE_BITS
     17u
-    CACHE STRING "Minimum number of preambel bits of command station")
+    CACHE STRING "Minimum number of preamble bits of command station")
 set(DCC_TX_MAX_PREAMBLE_BITS
     30u
-    CACHE STRING "Maximum number of preambel bits of command station")
+    CACHE STRING "Maximum number of preamble bits of command station")
 set(DCC_TX_MIN_BIT_1_TIMING
     56u
     CACHE STRING "Minimum duration of a 1 bit of command station")
@@ -137,14 +137,14 @@ target_compile_definitions(
             DCC_TX_MAX_BIDI_BIT_TIMING=${DCC_TX_MAX_BIDI_BIT_TIMING}
             DCC_TX_DEQUE_SIZE=${DCC_TX_DEQUE_SIZE})
 
-if(PROJECT_IS_TOP_LEVEL)
+# https://github.com/espressif/esp-idf/issues/17773
+if(PROJECT_IS_TOP_LEVEL AND NOT ESP_PLATFORM)
   target_include_directories(DCC INTERFACE include)
+  target_common_warnings(DCC INTERFACE)
+  target_common_errors(DCC INTERFACE)
 else()
   target_include_directories(DCC SYSTEM INTERFACE include)
 endif()
-
-target_common_warnings(DCC INTERFACE)
-target_compile_options(DCC INTERFACE "$<$<BOOL:${ESP_PLATFORM}>:-Wno-error>")
 
 if(NOT TARGET static_math)
   cpmaddpackage(
@@ -162,7 +162,7 @@ if(NOT TARGET static_math)
 endif()
 
 if(NOT TARGET ZTL::ZTL)
-  cpmaddpackage("gh:ZIMO-Elektronik/ZTL@0.23.0")
+  cpmaddpackage("gh:ZIMO-Elektronik/ZTL@0.23.1")
 endif()
 
 target_link_libraries(DCC INTERFACE static_math ZTL::ZTL)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DCC
 
-[![build](https://github.com/ZIMO-Elektronik/DCC/actions/workflows/build.yml/badge.svg)](https://github.com/ZIMO-Elektronik/DCC/actions/workflows/build.yml) [![tests](https://github.com/ZIMO-Elektronik/DCC/actions/workflows/tests.yml/badge.svg)](https://github.com/ZIMO-Elektronik/DCC/actions/workflows/tests.yml) [![license](https://img.shields.io/github/license/ZIMO-Elektronik/DCC)](https://github.com/ZIMO-Elektronik/DCC/raw/master/LICENSE)
+[![build](https://github.com/ZIMO-Elektronik/DCC/actions/workflows/build.yml/badge.svg)](https://github.com/ZIMO-Elektronik/DCC/actions/workflows/build.yml) [![tests](https://github.com/ZIMO-Elektronik/DCC/actions/workflows/tests.yml/badge.svg)](https://github.com/ZIMO-Elektronik/DCC/actions/workflows/tests.yml) [![release](https://github.com/ZIMO-Elektronik/DCC/actions/workflows/release.yml/badge.svg)](https://github.com/ZIMO-Elektronik/DCC/actions/workflows/release.yml) [![license](https://img.shields.io/github/license/ZIMO-Elektronik/DCC)](https://github.com/ZIMO-Elektronik/DCC/raw/master/LICENSE)
 
 <img src="https://github.com/ZIMO-Elektronik/DCC/raw/master/data/images/logo.gif" align="right"/>
 

--- a/examples/esp32/main/app_main.cpp
+++ b/examples/esp32/main/app_main.cpp
@@ -17,7 +17,9 @@ extern "C" void app_main() {
                                       .mem_block_symbols =
                                         SOC_RMT_CHANNELS_PER_GROUP *
                                         SOC_RMT_MEM_WORDS_PER_CHANNEL,
-                                      .trans_queue_depth = 2uz};
+                                      .trans_queue_depth = 2uz,
+                                      .intr_priority = 0,
+                                      .flags = {}};
   rmt_channel_handle_t rmt_channel{};
   ESP_ERROR_CHECK(rmt_new_tx_channel(&chan_config, &rmt_channel));
   ESP_ERROR_CHECK(rmt_enable(rmt_channel));

--- a/examples/repl/CMakeLists.txt
+++ b/examples/repl/CMakeLists.txt
@@ -2,6 +2,7 @@ file(GLOB_RECURSE SRC src/*.cpp)
 add_executable(DCCRepl ${SRC})
 
 target_common_warnings(DCCRepl PRIVATE)
+target_common_errors(DCCRepl PRIVATE)
 
 cpmaddpackage("gh:daniele77/cli@2.2.0")
 

--- a/examples/stm32/CMakeLists.txt
+++ b/examples/stm32/CMakeLists.txt
@@ -37,6 +37,9 @@ function(add_stm32_target TARGET)
       ${STM32CubeH7_SOURCE_DIR}/Projects/NUCLEO-H743ZI/Applications/FreeRTOS/FreeRTOS_MPU/Src/system_stm32h7xx.c
   )
 
+  target_common_warnings(${TARGET} PRIVATE)
+  target_common_errors(${TARGET} PRIVATE)
+
   target_link_libraries(${TARGET} PRIVATE DCC::DCC)
 
   target_link_libraries(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,8 +6,7 @@ add_executable(DCCTests ${SRC})
 sanitize(address,undefined)
 
 target_common_warnings(DCCTests PRIVATE)
-
-target_compile_options(DCC INTERFACE -Werror;-Wno-error=deprecated-declarations)
+target_common_errors(DCCTests PRIVATE -Werror)
 
 cpmaddpackage(
   NAME

--- a/tests/rx/app_adr.cpp
+++ b/tests/rx/app_adr.cpp
@@ -8,17 +8,18 @@ TEST_F(RxTest, app_adr_alternate_primary_id1_id2) {
   auto adr_low{encode_datagram(
     make_datagram<Bits::_12>(2u, static_cast<uint8_t>(_addrs.primary)))};
 
+  // Send whatever packet to get last received address to match primary
+  auto packet{make_function_group_f4_f0_packet(_addrs.primary, 10u)};
+  Receive(packet);
+
   InSequence s;
   for (auto i{0uz}; i < 10uz; ++i) {
-    // Send whatever packet to get last received address to match primary
-    Receive(make_function_group_f4_f0_packet(_addrs.primary, 10u));
+    LeaveCutout()->Execute()->Receive(packet);
 
     EXPECT_CALL(_mock, transmitBiDi(DatagramMatcher(adr_high))).Times(1);
-    Execute();
     _mock.biDiChannel1();
 
     EXPECT_CALL(_mock, transmitBiDi(DatagramMatcher(adr_low))).Times(1);
-    Execute();
     _mock.biDiChannel1();
   }
 }
@@ -32,17 +33,18 @@ TEST_F(RxTest, app_adr_alternate_logon_id1_id2) {
   auto adr_low{
     encode_datagram(make_datagram<Bits::_12>(2u, _addrs.logon & 0x00FFu))};
 
+  // Send whatever packet to get last received address to match primary
+  auto packet{make_function_group_f4_f0_packet(_addrs.primary, 10u)};
+  Receive(packet);
+
   InSequence s;
   for (auto i{0uz}; i < 10uz; ++i) {
-    // Send whatever packet to get last received address to match logon
-    Receive(make_function_group_f4_f0_packet(_addrs.logon, 10u));
+    LeaveCutout()->Execute()->Receive(packet);
 
     EXPECT_CALL(_mock, transmitBiDi(DatagramMatcher(adr_high))).Times(1);
-    Execute();
     _mock.biDiChannel1();
 
     EXPECT_CALL(_mock, transmitBiDi(DatagramMatcher(adr_low))).Times(1);
-    Execute();
     _mock.biDiChannel1();
   }
 }
@@ -59,7 +61,7 @@ TEST_F(RxTest, app_adr_disabled_with_cv28_0) {
   _mock.biDiChannel1();
 }
 
-TEST_F(RxTest, app_adr_consist) {
+TEST_F(RxTest, app_adr_alternate_consist_id1_id2) {
   _cvs[19uz - 1uz] = static_cast<uint8_t>(_addrs.consist);
   SetUp();
 
@@ -68,19 +70,23 @@ TEST_F(RxTest, app_adr_consist) {
   auto adr_low{encode_datagram(
     make_datagram<Bits::_12>(2u, static_cast<uint8_t>(_addrs.consist)))};
 
-  // Send whatever packet to get last received address to match consist
-  Receive(make_function_group_f4_f0_packet(_addrs.consist, 10u));
+  // Send whatever packet to get last received address to match primary
+  auto packet{make_function_group_f4_f0_packet(_addrs.consist, 10u)};
+  Receive(packet);
 
-  EXPECT_CALL(_mock, transmitBiDi(DatagramMatcher(adr_high))).Times(1);
-  Execute();
-  _mock.biDiChannel1();
+  InSequence s;
+  for (auto i{0uz}; i < 10uz; ++i) {
+    LeaveCutout()->Execute()->Receive(packet);
 
-  EXPECT_CALL(_mock, transmitBiDi(DatagramMatcher(adr_low))).Times(1);
-  Execute();
-  _mock.biDiChannel1();
+    EXPECT_CALL(_mock, transmitBiDi(DatagramMatcher(adr_high))).Times(1);
+    _mock.biDiChannel1();
+
+    EXPECT_CALL(_mock, transmitBiDi(DatagramMatcher(adr_low))).Times(1);
+    _mock.biDiChannel1();
+  }
 }
 
-TEST_F(RxTest, app_adr_long_consist) {
+TEST_F(RxTest, app_adr_alternate_long_consist_id1_id2) {
   _cvs[19uz - 1uz] = 83u;
   _cvs[20uz - 1uz] = 12u;
   _addrs.consist = static_cast<dcc::Address::value_type>(
@@ -94,16 +100,20 @@ TEST_F(RxTest, app_adr_long_consist) {
   auto adr_low{
     encode_datagram(make_datagram<Bits::_12>(2u, _addrs.consist & 0x00FFu))};
 
-  // Send whatever packet to get last received address to match consist
-  Receive(make_function_group_f4_f0_packet(_addrs.consist, 10u));
+  // Send whatever packet to get last received address to match primary
+  auto packet{make_function_group_f4_f0_packet(_addrs.consist, 10u)};
+  Receive(packet);
 
-  EXPECT_CALL(_mock, transmitBiDi(DatagramMatcher(adr_high))).Times(1);
-  Execute();
-  _mock.biDiChannel1();
+  InSequence s;
+  for (auto i{0uz}; i < 10uz; ++i) {
+    LeaveCutout()->Execute()->Receive(packet);
 
-  EXPECT_CALL(_mock, transmitBiDi(DatagramMatcher(adr_low))).Times(1);
-  Execute();
-  _mock.biDiChannel1();
+    EXPECT_CALL(_mock, transmitBiDi(DatagramMatcher(adr_high))).Times(1);
+    _mock.biDiChannel1();
+
+    EXPECT_CALL(_mock, transmitBiDi(DatagramMatcher(adr_low))).Times(1);
+    _mock.biDiChannel1();
+  }
 }
 
 TEST_F(RxTest, app_adr_broadcast) {
@@ -112,17 +122,18 @@ TEST_F(RxTest, app_adr_broadcast) {
   auto adr_low{encode_datagram(
     make_datagram<Bits::_12>(2u, static_cast<uint8_t>(_addrs.primary)))};
 
+  // Broadcast
+  auto packet{dcc::make_speed_and_direction_packet(0u, 0u)};
+  Receive(packet);
+
   InSequence s;
   for (auto i{0uz}; i < 10uz; ++i) {
-    // Broadcast
-    Receive(dcc::make_speed_and_direction_packet(0u, 0u));
+    LeaveCutout()->Execute()->Receive(packet);
 
     EXPECT_CALL(_mock, transmitBiDi(DatagramMatcher(adr_high))).Times(0);
-    Execute();
     _mock.biDiChannel1();
 
     EXPECT_CALL(_mock, transmitBiDi(DatagramMatcher(adr_low))).Times(0);
-    Execute();
     _mock.biDiChannel1();
   }
 }

--- a/tests/rx/app_dyn.cpp
+++ b/tests/rx/app_dyn.cpp
@@ -9,10 +9,10 @@ TEST_F(RxTest, app_dyn) {
   EXPECT_LT(DCC_RX_BIDI_DEQUE_SIZE, 42uz);
 
   // Add more datagrams than would fit the queue
-  for (auto i{0u}; i < 42u; ++i)
+  for (auto i{0uz}; i < 42u; ++i)
     _mock.datagram(DirectionStatusByte{static_cast<uint8_t>(i)});
 
-  auto i{0u};
+  auto i{0uz};
 
   {
     // First datagram after deque release is always QoS
@@ -68,7 +68,7 @@ TEST_F(RxTest, dont_transmit_following_foreign_address) {
   Receive(dcc::make_function_group_f4_f0_packet(1817u, 10u));
 
   // Add more datagrams than would fit the queue
-  for (auto i{0u}; i < 42u; ++i)
+  for (auto i{0uz}; i < 42u; ++i)
     _mock.datagram(DirectionStatusByte{static_cast<uint8_t>(i)});
 
   EXPECT_CALL(_mock, transmitBiDi(_)).Times(0);

--- a/tests/rx/app_tos.cpp
+++ b/tests/rx/app_tos.cpp
@@ -10,8 +10,9 @@ TEST_F(RxTest, app_tos_basic_address) {
   SetUp();
 
   // Make sure to get past backoff (see RCN-218)
-  for (auto i{0u}; i < 30.0 / 10E-3; ++i)
-    ReceiveAndExecute(dcc::make_binary_state_short_packet(0u, 2u));
+  for (auto i{0.0}; i < 30.0 / 10E-3; ++i)
+    LeaveCutout()->Execute()->Receive(
+      dcc::make_binary_state_short_packet(0u, 2u));
 
   // Make datagram
   auto adr_high{encode_datagram(make_datagram<Bits::_12>(1u, 0u))};
@@ -34,8 +35,9 @@ TEST_F(RxTest, app_tos_extended_address) {
   SetUp();
 
   // Make sure to get past backoff (see RCN-218)
-  for (auto i{0u}; i < 30.0 / 10E-3; ++i)
-    ReceiveAndExecute(dcc::make_binary_state_short_packet(0u, 2u));
+  for (auto i{0.0}; i < 30.0 / 10E-3; ++i)
+    LeaveCutout()->Execute()->Receive(
+      dcc::make_binary_state_short_packet(0u, 2u));
 
   // Make datagram
   auto adr_high{encode_datagram(
@@ -58,8 +60,9 @@ TEST_F(
   SetUp();
 
   // Make sure to get past backoff (see RCN-218)
-  for (auto i{0u}; i < 30.0 / 10E-3; ++i)
-    ReceiveAndExecute(dcc::make_binary_state_short_packet(0u, 2u));
+  for (auto i{0.0}; i < 30.0 / 10E-3; ++i)
+    LeaveCutout()->Execute()->Receive(
+      dcc::make_binary_state_short_packet(0u, 2u));
 
   // Make datagram
   auto adr_high{encode_datagram(make_datagram<Bits::_12>(1u, 0u))};
@@ -77,8 +80,9 @@ TEST_F(
   std::this_thread::sleep_for(1s);
 
   // Make sure to get past backoff (see RCN-218)
-  for (auto i{0u}; i < 30.0 / 10E-3; ++i)
-    ReceiveAndExecute(dcc::make_binary_state_short_packet(0u, 2u));
+  for (auto i{0.0}; i < 30.0 / 10E-3; ++i)
+    LeaveCutout()->Execute()->Receive(
+      dcc::make_binary_state_short_packet(0u, 2u));
 
   EXPECT_CALL(_mock, transmitBiDi(DatagramMatcher(datagram))).Times(1);
   _mock.biDiChannel2();

--- a/tests/rx/backoff_test.hpp
+++ b/tests/rx/backoff_test.hpp
@@ -5,7 +5,6 @@
 #include <dcc/dcc.hpp>
 
 struct BackoffTest : ::testing::Test {
-protected:
   BackoffTest();
   virtual ~BackoffTest();
 

--- a/tests/rx/consist_control.cpp
+++ b/tests/rx/consist_control.cpp
@@ -1,21 +1,7 @@
 #include "rx_test.hpp"
 
 TEST_F(RxTest, consist_control) {
-  EXPECT_CALL(_mock, readCv(_))
-    .WillOnce(Return(_cvs[29uz - 1uz]))
-    .WillOnce(Return(_cvs[1uz - 1uz]))
-    .WillOnce(Return(_cvs[19uz - 1uz]))
-    .WillOnce(Return(_cvs[20uz - 1uz]))
-    .WillOnce(Return(_cvs[15uz - 1uz]))
-    .WillOnce(Return(_cvs[16uz - 1uz]))
-    .WillOnce(Return(_cvs[28uz - 1uz]))
-    .WillOnce(Return(_cvs[DCC_RX_LOGON_DID_CV_ADDRESS + 0uz]))
-    .WillOnce(Return(_cvs[DCC_RX_LOGON_DID_CV_ADDRESS + 1uz]))
-    .WillOnce(Return(_cvs[DCC_RX_LOGON_DID_CV_ADDRESS + 2uz]))
-    .WillOnce(Return(_cvs[DCC_RX_LOGON_DID_CV_ADDRESS + 3uz]))
-    .WillOnce(Return(_cvs[DCC_RX_LOGON_CID_CV_ADDRESS + 0uz]))
-    .WillOnce(Return(_cvs[DCC_RX_LOGON_CID_CV_ADDRESS + 1uz]))
-    .WillOnce(Return(_cvs[DCC_RX_LOGON_SID_CV_ADDRESS]));
+  BASIC_ADDRESS_EXPECT_CALL_READ_CV_INIT_SEQUENCE();
   auto cv19{RandomInterval<uint8_t>(0u, 255u)};
   auto packet{make_consist_control_packet(_addrs.primary, cv19)};
 

--- a/tests/rx/rx_test.hpp
+++ b/tests/rx/rx_test.hpp
@@ -8,16 +8,17 @@ using namespace ::testing;
 
 // Receive test fixture
 struct RxTest : ::testing::Test {
-protected:
   RxTest();
   virtual ~RxTest();
 
   void SetUp() override;
 
-  void Receive(dcc::Packet const& packet);
-  void Receive(dcc::tx::Timings const& timings);
-  void Execute();
-  void BiDi();
+  RxTest* Receive(dcc::Packet const& packet);
+  RxTest* BiDiChannel1();
+  RxTest* BiDiChannel2();
+  RxTest* BiDi();
+  RxTest* LeaveCutout();
+  RxTest* Execute();
 
   void EnterServiceMode();
 
@@ -32,16 +33,15 @@ protected:
     return dis(gen);
   }
 
-  template<typename T>
-  void ReceiveAndExecute(T&& t) {
-    Receive(std::forward<T>(t));
-    Execute();
+  /// \todo this needs to go
+  void ReceiveAndExecute(dcc::Packet const& packet) {
+    Receive(packet)->LeaveCutout()->Execute();
   }
 
-  template<typename T>
-  void ReceiveAndExecuteTwice(T&& t) {
-    ReceiveAndExecute(std::forward<T>(t));
-    ReceiveAndExecute(std::forward<T>(t));
+  /// \todo this needs to go
+  void ReceiveAndExecuteTwice(dcc::Packet const& packet) {
+    ReceiveAndExecute(packet);
+    ReceiveAndExecute(packet);
   }
 
   NiceMock<RxMock> _mock;
@@ -58,3 +58,42 @@ protected:
 MATCHER_P(DatagramMatcher, datagram, "") {
   return std::equal(cbegin(datagram), cend(datagram), cbegin(arg));
 }
+
+#define BASIC_ADDRESS_EXPECT_CALL_READ_CV_INIT_SEQUENCE()                      \
+  EXPECT_CALL(_mock, readCv(_))                                                \
+    .WillOnce(Return(_cvs[29uz - 1uz]))                                        \
+    .WillOnce(Return(_cvs[1uz - 1uz]))                                         \
+    .WillOnce(Return(_cvs[19uz - 1uz]))                                        \
+    .WillOnce(Return(_cvs[20uz - 1uz]))                                        \
+    .WillOnce(Return(_cvs[15uz - 1uz]))                                        \
+    .WillOnce(Return(_cvs[16uz - 1uz]))                                        \
+    .WillOnce(Return(_cvs[28uz - 1uz]))                                        \
+    .WillOnce(Return(_cvs[DCC_RX_LOGON_DID_CV_ADDRESS + 0uz]))                 \
+    .WillOnce(Return(_cvs[DCC_RX_LOGON_DID_CV_ADDRESS + 1uz]))                 \
+    .WillOnce(Return(_cvs[DCC_RX_LOGON_DID_CV_ADDRESS + 2uz]))                 \
+    .WillOnce(Return(_cvs[DCC_RX_LOGON_DID_CV_ADDRESS + 3uz]))                 \
+    .WillOnce(Return(_cvs[DCC_RX_LOGON_CID_CV_ADDRESS + 0uz]))                 \
+    .WillOnce(Return(_cvs[DCC_RX_LOGON_CID_CV_ADDRESS + 1uz]))                 \
+    .WillOnce(Return(_cvs[DCC_RX_LOGON_SID_CV_ADDRESS]))                       \
+    .WillOnce(Return(_cvs[DCC_RX_LOGON_ADDRESS_CV_ADDRESS + 0u]))              \
+    .WillOnce(Return(_cvs[DCC_RX_LOGON_ADDRESS_CV_ADDRESS + 1u]))
+
+#define EXTENDED_ADDRESS_EXPECT_CALL_READ_CV_INIT_SEQUENCE()                   \
+  EXPECT_CALL(_mock, readCv(_))                                                \
+    .WillOnce(Return(_cvs[29uz - 1uz]))                                        \
+    .WillOnce(Return(_cvs[17uz - 1uz]))                                        \
+    .WillOnce(Return(_cvs[18uz - 1uz]))                                        \
+    .WillOnce(Return(_cvs[19uz - 1uz]))                                        \
+    .WillOnce(Return(_cvs[20uz - 1uz]))                                        \
+    .WillOnce(Return(_cvs[15uz - 1uz]))                                        \
+    .WillOnce(Return(_cvs[16uz - 1uz]))                                        \
+    .WillOnce(Return(_cvs[28uz - 1uz]))                                        \
+    .WillOnce(Return(_cvs[DCC_RX_LOGON_DID_CV_ADDRESS + 0uz]))                 \
+    .WillOnce(Return(_cvs[DCC_RX_LOGON_DID_CV_ADDRESS + 1uz]))                 \
+    .WillOnce(Return(_cvs[DCC_RX_LOGON_DID_CV_ADDRESS + 2uz]))                 \
+    .WillOnce(Return(_cvs[DCC_RX_LOGON_DID_CV_ADDRESS + 3uz]))                 \
+    .WillOnce(Return(_cvs[DCC_RX_LOGON_CID_CV_ADDRESS + 0uz]))                 \
+    .WillOnce(Return(_cvs[DCC_RX_LOGON_CID_CV_ADDRESS + 1uz]))                 \
+    .WillOnce(Return(_cvs[DCC_RX_LOGON_SID_CV_ADDRESS]))                       \
+    .WillOnce(Return(_cvs[DCC_RX_LOGON_ADDRESS_CV_ADDRESS + 0u]))              \
+    .WillOnce(Return(_cvs[DCC_RX_LOGON_ADDRESS_CV_ADDRESS + 1u]))

--- a/tests/tx/tx_test.hpp
+++ b/tests/tx/tx_test.hpp
@@ -8,7 +8,6 @@ using namespace ::testing;
 
 // Transmit test fixture
 struct TxTest : ::testing::Test {
-protected:
   TxTest();
   virtual ~TxTest();
 


### PR DESCRIPTION
Closes #110 