### PR TITLE
fix: CV access packets are answered with 2x ACKs as long as busy (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##
 - Block `rx::CrtpBase::biDiChannel1` and `rx::CrtpBase::biDiChannel2` outside of BiDi cutout ([#110](https://github.com/ZIMO-Elektronik/DCC/issues/110))
 - Bugfix [RCN-217](https://normen.railcommunity.de/RCN-217.pdf) explicitly requires that ID0 datagrams must follow any packet ([#113](https://github.com/ZIMO-Elektronik/DCC/issues/113))
+- Bugfix CV access packets are answered with 2x ACKs as long as busy ([#114](https://github.com/ZIMO-Elektronik/DCC/issues/114))
 
 ## 0.44.5
 - Bugfix `make_logon_assign_packet` ([#102](https://github.com/ZIMO-Elektronik/DCC/issues/102))

--- a/include/dcc/rx/crtp_base.hpp
+++ b/include/dcc/rx/crtp_base.hpp
@@ -1157,7 +1157,7 @@ private:
     }
     // Implicitly acknowledge all CV access commands
     else
-      impl().transmitBiDi({cbegin(acks), sizeof(acks[0uz])});
+      impl().transmitBiDi(acks);
   }
 
   /// Handle app:dyn


### PR DESCRIPTION
Closes #114 