### PR TITLE
fix: unknown BiDi ID causes out of bounds access (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-##
+## 0.45.0
 - Block `rx::CrtpBase::biDiChannel1` and `rx::CrtpBase::biDiChannel2` outside of BiDi cutout ([#110](https://github.com/ZIMO-Elektronik/DCC/issues/110))
 - Bugfix [RCN-217](https://normen.railcommunity.de/RCN-217.pdf) explicitly requires that ID0 datagrams must follow any packet ([#113](https://github.com/ZIMO-Elektronik/DCC/issues/113))
 - Bugfix CV access packets are answered with 2x ACKs as long as busy ([#114](https://github.com/ZIMO-Elektronik/DCC/issues/114))
+- Bugfix unknown BiDi ID causes out of bounds access ([#130](https://github.com/ZIMO-Elektronik/DCC/issues/130))
 
 ## 0.44.5
 - Bugfix `make_logon_assign_packet` ([#102](https://github.com/ZIMO-Elektronik/DCC/issues/102))

--- a/include/dcc/bidi/dissector.hpp
+++ b/include/dcc/bidi/dissector.hpp
@@ -129,7 +129,7 @@ struct Dissector : std::ranges::view_interface<Dissector> {
   }
 
   constexpr bool operator==(std::default_sentinel_t) const {
-    return _i >= bundled_channels_size || !_encoded[_i];
+    return _i >= bundled_channels_size || !_encoded[_i] || std::empty(next());
   }
 
   constexpr Dissector& begin() { return *this; }

--- a/tests/bidi/dissector.cpp
+++ b/tests/bidi/dissector.cpp
@@ -147,3 +147,12 @@ TEST(Dissector, invalid) {
     EXPECT_EQ(expected, result);
   }
 }
+
+TEST(Dissector, unknown_id) {
+  {
+    dcc::Packet packet{0x03u, 0x3Fu, 0x80u, 0xBCu};
+    Datagram<> datagram{0x2Du, 0xCAu, 0x59u, 0x96u, 0x66u, 0x5Au, 0xACu, 0xACu};
+    Dissector dissector{datagram, packet};
+    EXPECT_EQ(cbegin(dissector), cend(dissector));
+  }
+}


### PR DESCRIPTION
Closes #130 