### PR TITLE
change: dissector returns pom only if at index 2 (or 4 depending on context)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.46.1
+- Bugfix workaround for old app:info (id3) datagrams in channel 2 ([#138](https://github.com/ZIMO-Elektronik/DCC/issues/138))
+
 ## 0.46.0
 - Add `DCCypher` web app ([#126](https://github.com/ZIMO-Elektronik/DCC/pull/126))
 - Add accessory support to `bidi::Dissector` ([#98](https://github.com/ZIMO-Elektronik/DCC/issues/98))

--- a/include/dcc/bidi/dissector.hpp
+++ b/include/dcc/bidi/dissector.hpp
@@ -249,7 +249,12 @@ private:
       case Address::BasicLoco: [[fallthrough]];
       case Address::ExtendedLoco:
         switch (id) {
-          case app::Pom::id: [[fallthrough]];
+          case app::Pom::id: // (double) POM must be at start of channel 2
+            if (_i == channel1_size ||
+                (_i - datagram_size<Bits::_12> == channel1_size &&
+                 _decoded[channel1_size] >> 2u == id))
+              return {&_decoded[_i], datagram_size<Bits::_12>};
+            return {};
           case app::AdrHigh::id: [[fallthrough]];
           case app::AdrLow::id:
             return {&_decoded[_i], datagram_size<Bits::_12>};


### PR DESCRIPTION
A rather primitive approach, but this should work without breaking anything. 