### PR TITLE
fix: `rx::CrtpBase::init()` clears deques (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.46.2
+- Bugfix `rx::CrtpBase::init()` clears deques ([#141](https://github.com/ZIMO-Elektronik/DCC/issues/141))
 - Bugfix CV bit manipulation operations mode ([#142](https://github.com/ZIMO-Elektronik/DCC/issues/142))
 
 ## 0.46.1

--- a/include/dcc/rx/crtp_base.hpp
+++ b/include/dcc/rx/crtp_base.hpp
@@ -107,6 +107,13 @@ struct CrtpBase {
 
     // Initialization time point
     _tps.init = std::chrono::system_clock::now();
+
+    // Clear deques
+    _dyn_deque.clear();
+    _logon_deque.clear();
+    _search_deque.clear();
+    _adr_deque.clear();
+    _pom.deque.clear();
   }
 
   /// Enable

--- a/tests/rx/app_search.cpp
+++ b/tests/rx/app_search.cpp
@@ -81,3 +81,26 @@ TEST_F(
   EXPECT_CALL(_mock, transmitBiDi(DatagramMatcher(datagram))).Times(1);
   _mock.biDiChannel2();
 }
+
+TEST_F(RxTest, app_search_address_change_must_clear_deque) {
+  BASIC_ADDRESS_EXPECT_CALL_READ_CV_INIT_SEQUENCE();
+
+  // Make sure to get past backoff (see RCN-218)
+  for (auto i{0.0}; i < 30.0 / 10E-3; ++i)
+    Receive(dcc::make_binary_state_short_packet(0u, 2u, false))
+      ->LeaveCutout()
+      ->Execute();
+
+  // Change address
+  for (auto i{0uz}; i < 2uz; ++i)
+    ReceiveAndExecute(make_cv_access_long_write_packet(_addrs.primary, 0u, 4u));
+
+  // Receive any broadcast
+  Receive(dcc::make_speed_and_direction_packet(0u, 0u));
+
+  // Make datagram
+  auto datagram{make_app_search_datagram(_addrs.primary, 0u, 0u)};
+
+  EXPECT_CALL(_mock, transmitBiDi(DatagramMatcher(datagram))).Times(0);
+  _mock.biDiChannel2();
+}

--- a/tests/rx/cv_long.cpp
+++ b/tests/rx/cv_long.cpp
@@ -93,7 +93,7 @@ TEST_F(RxTest, cv_long_write_byte_operations_mode) {
                       Matcher<std::function<void(uint8_t)>>(_)))
     .WillOnce(InvokeArgument<2uz>(byte));
   ReceiveAndExecuteTwice(
-    dcc::make_cv_access_long_write_packet(_addrs.primary, cv_addr, byte));
+    make_cv_access_long_write_packet(_addrs.primary, cv_addr, byte));
 }
 
 TEST_F(


### PR DESCRIPTION
Closes #141 