### PR TITLE
feat: tx - add getter for address of the last transmission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.46.2
+- Add getter for address of last transmission to `tx::CrtpBase` ([#140](https://github.com/ZIMO-Elektronik/DCC/issues/140))
 - Bugfix `rx::CrtpBase::init()` clears deques ([#141](https://github.com/ZIMO-Elektronik/DCC/issues/141))
 - Bugfix CV bit manipulation operations mode ([#142](https://github.com/ZIMO-Elektronik/DCC/issues/142))
 

--- a/README.md
+++ b/README.md
@@ -135,13 +135,13 @@ This library is meant to be consumed with CMake,
 
 ```cmake
 # Either by including it with CPM
-cpmaddpackage("gh:ZIMO-Elektronik/DCC@0.45.0")
+cpmaddpackage("gh:ZIMO-Elektronik/DCC@0.46.2")
 
 # or the FetchContent module
 FetchContent_Declare(
   DCC
   GIT_REPOSITORY "https://github.com/ZIMO-Elektronik/DCC"
-  GIT_TAG v0.45.0)
+  GIT_TAG v0.46.2)
 
 target_link_libraries(YourTarget PRIVATE DCC::DCC)
 ```
@@ -150,7 +150,7 @@ or, on [ESP32 platforms](https://www.espressif.com/en/products/socs/esp32), with
 ```yaml
 dependencies:
   zimo-elektronik/dcc:
-    version: "0.45.0"
+    version: "0.46.2"
 ```
 
 A number of [options](CMakeLists.txt) are provided to configure various sizes such as the receiver deque length or the maximum packet length. When RAM becomes scarce, deque lengths can be reduced. On the other hand, if the processing of the commands is too slow and cannot be done every few milliseconds, it can make sense to lengthen the deques and batch process several commands at once. Otherwise, we recommend sticking with the defaults.
@@ -213,7 +213,7 @@ dcc> Address 3: set speed 18
 On [ESP32 platforms](https://www.espressif.com/en/products/socs/esp32) examples from the [examples](https://github.com/ZIMO-Elektronik/DCC/raw/master/examples) subfolder can be built directly using the [IDF Frontend](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/tools/idf-py.html).
 
 ```sh
-idf.py create-project-from-example "zimo-elektronik/dcc^0.45.0:esp32"
+idf.py create-project-from-example "zimo-elektronik/dcc^0.46.2:esp32"
 ```
 
 #### STM32

--- a/include/dcc/bidi/dissector.hpp
+++ b/include/dcc/bidi/dissector.hpp
@@ -11,7 +11,6 @@
 #pragma once
 
 #include <bit>
-#include <cassert>
 #include <climits>
 #include <variant>
 #include <ztl/limits.hpp>

--- a/include/dcc/rx/addresses.hpp
+++ b/include/dcc/rx/addresses.hpp
@@ -2,17 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-/// Addresses
+/// Receive addresses
 ///
-/// \file   dcc/addresses.hpp
+/// \file   dcc/rx/addresses.hpp
 /// \author Vincent Hamp
 /// \date   04/01/2022
 
 #pragma once
 
-#include "address.hpp"
+#include "../address.hpp"
 
-namespace dcc {
+namespace dcc::rx {
 
 struct Addresses {
   Address primary{};
@@ -21,4 +21,4 @@ struct Addresses {
   Address received{};
 };
 
-} // namespace dcc
+} // namespace dcc::rx

--- a/include/dcc/rx/crtp_base.hpp
+++ b/include/dcc/rx/crtp_base.hpp
@@ -10,12 +10,12 @@
 
 #pragma once
 
+#include <cassert>
 #include <chrono>
 #include <concepts>
 #include <span>
 #include <ztl/bits.hpp>
 #include <ztl/inplace_deque.hpp>
-#include "../addresses.hpp"
 #include "../bidi/acks.hpp"
 #include "../bidi/channel.hpp"
 #include "../bidi/datagram.hpp"
@@ -31,6 +31,7 @@
 #include "../packet.hpp"
 #include "../speed.hpp"
 #include "../utility.hpp"
+#include "addresses.hpp"
 #include "async_readable.hpp"
 #include "async_writable.hpp"
 #include "backoff.hpp"

--- a/include/dcc/tx/addresses.hpp
+++ b/include/dcc/tx/addresses.hpp
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// Transmit addresses
+///
+/// \file   dcc/tx/addresses.hpp
+/// \author Vincent Hamp
+/// \date   16/03/2026
+
+#pragma once
+
+#include "../address.hpp"
+
+namespace dcc::tx {
+
+struct Addresses {
+  Address current{};
+  Address last{};
+};
+
+} // namespace dcc::tx

--- a/include/dcc/tx/crtp_base.hpp
+++ b/include/dcc/tx/crtp_base.hpp
@@ -10,12 +10,15 @@
 
 #pragma once
 
+#include <cassert>
 #include <concepts>
 #include <span>
+#include <utility>
 #include <ztl/inplace_deque.hpp>
 #include "../bidi/datagram.hpp"
 #include "../bidi/timing.hpp"
 #include "../utility.hpp"
+#include "addresses.hpp"
 #include "command_station.hpp"
 #include "config.hpp"
 #include "timings.hpp"
@@ -32,8 +35,9 @@ requires(std::same_as<D, Packet> || std::same_as<D, Timings>)
 struct CrtpBase {
   friend T;
 
-  using value_type =
-    std::conditional_t<std::same_as<D, Packet>, TimingsAdapter, Timings>;
+  using value_type = std::pair<
+    Address,
+    std::conditional_t<std::same_as<D, Packet>, TimingsAdapter, Timings>>;
 
   /// Initialize
   ///
@@ -45,12 +49,14 @@ struct CrtpBase {
            cfg.bit1_duration >= Bit1Min && cfg.bit1_duration <= Bit1Max && //
            cfg.bit0_duration >= Bit0Min && cfg.bit0_duration <= Bit0Max);  //
     _cfg = cfg;
+    _idle_packet.first = _addrs.current = decode_address(packet);
     if constexpr (std::same_as<D, Packet>)
-      _idle_packet = TimingsAdapter{packet, _cfg};
+      _idle_packet.second = TimingsAdapter{packet, _cfg};
     else if constexpr (std::same_as<D, Timings>)
-      _idle_packet = bytes2timings(packet, _cfg);
-    _first = begin(_idle_packet);
-    _last = cend(_idle_packet);
+      _idle_packet.second = bytes2timings(packet, _cfg);
+    _first = begin(_idle_packet.second);
+    _last = cend(_idle_packet.second);
+    _idle = true;
   }
 
   /// Transmit packet
@@ -80,31 +86,30 @@ struct CrtpBase {
   Timings::value_type transmit() {
     // Packet timings
     if (_first != _last) return packetTiming();
+
     // Packet end
-    else if constexpr (requires(T t) {
-                         { t.packetEnd() };
-                       })
+    if constexpr (requires(T t) {
+                    { t.packetEnd() };
+                  })
       if (!_bidi_count) impl().packetEnd();
 
     // BiDi timings
     if (_cfg.flags.bidi && _bidi_count <= 4uz) return biDiTiming();
     else _bidi_count = 0uz;
 
-    // Deque is empty, transmit idle packet
-    if (empty(_deque)) {
-      _first = begin(_idle_packet);
-      _last = cend(_idle_packet);
-    }
-    // Deque contains packet, transmit it
-    else {
-      _first = begin(_deque.front());
-      _last = cend(_deque.front());
-      /// \warning
-      /// Careful! This only works because of the design of ztl::inplace_deque.
-      /// The element currently pointed to will stay valid until the next call
-      /// of pop_front().
+    // Only pop if packet came from deque
+    if (!_idle) {
+      assert(!empty(_deque));
       _deque.pop_front();
     }
+
+    // Next packet
+    _idle = empty(_deque);
+    auto& packet{_idle ? _idle_packet : _deque.front()};
+    _addrs.last = _addrs.current;
+    _addrs.current = packet.first;
+    _first = begin(packet.second);
+    _last = cend(packet.second);
     return packetTiming();
   }
 
@@ -117,6 +122,11 @@ struct CrtpBase {
   ///
   /// \return Deque capacity
   constexpr auto capacity() const { return DCC_TX_DEQUE_SIZE; }
+
+  /// Get address of last transmission
+  ///
+  /// \return Address of last transmission
+  constexpr auto address() const { return _addrs.last; }
 
 private:
   constexpr CrtpBase() = default;
@@ -186,9 +196,10 @@ private:
   ///
   /// \param  bytes Bytes containing DCC packet
   void pushBack(std::span<uint8_t const> bytes) {
-    if constexpr (std::same_as<D, Packet>) _deque.push_back({bytes, _cfg});
+    if constexpr (std::same_as<D, Packet>)
+      _deque.push_back({decode_address(bytes), {bytes, _cfg}});
     else if constexpr (std::same_as<D, Timings>)
-      _deque.push_back(bytes2timings(bytes, _cfg));
+      _deque.push_back({decode_address(bytes), bytes2timings(bytes, _cfg)});
   }
 
   /// Toggle track outputs
@@ -208,13 +219,19 @@ private:
   /// Idle packet
   value_type _idle_packet{};
 
+  /// Addresses
+  Addresses _addrs{};
+
   /// Iterators
-  decltype(std::begin(_idle_packet)) _first{std::begin(_idle_packet)};
-  decltype(std::cend(_idle_packet)) _last{std::cend(_idle_packet)};
+  decltype(std::begin(_idle_packet.second)) _first{
+    std::begin(_idle_packet.second)};
+  decltype(std::cend(_idle_packet.second)) _last{
+    std::cend(_idle_packet.second)};
 
   size_t _bidi_count{}; ///< Count BiDi timings
   Config _cfg{};        ///< Configuration
   bool _polarity{};     ///< Track polarity
+  bool _idle{true};     ///< Idle flag
 };
 
 } // namespace dcc::tx

--- a/tests/rx/rx_test.hpp
+++ b/tests/rx/rx_test.hpp
@@ -33,19 +33,17 @@ struct RxTest : ::testing::Test {
     return dis(gen);
   }
 
-  /// \todo this needs to go
   void ReceiveAndExecute(dcc::Packet const& packet) {
     Receive(packet)->LeaveCutout()->Execute();
   }
 
-  /// \todo this needs to go
   void ReceiveAndExecuteTwice(dcc::Packet const& packet) {
     ReceiveAndExecute(packet);
     ReceiveAndExecute(packet);
   }
 
   NiceMock<RxMock> _mock;
-  dcc::Addresses _addrs{
+  dcc::rx::Addresses _addrs{
     .primary = {.value = 3u, .type = dcc::Address::BasicLoco},
     .consist = {.value = 4u, .type = dcc::Address::BasicLoco},
     .logon = {.value = 1000u, .type = dcc::Address::ExtendedLoco}};

--- a/tests/tx/address.cpp
+++ b/tests/tx/address.cpp
@@ -1,0 +1,101 @@
+#include "tx_test.hpp"
+
+TEST_F(TxTest, address) {
+  _cfg.flags.bidi = false;
+  SetUp();
+
+  dcc::Address addr{.value = 3u, .type = dcc::Address::BasicLoco};
+
+  auto packet{dcc::make_128_speed_step_control_packet(addr, 0x00u)};
+  EXPECT_ALL_TRUE(_packet_mock.packet(packet), _timings_mock.packet(packet));
+  auto timings{dcc::tx::packet2timings(packet, _cfg)};
+  auto bits{(_cfg.num_preamble +                  // Preamble
+             std::size(packet) * (1uz + CHAR_BIT) // Start + data
+             + 1uz) *                             // End
+            2uz};
+
+  for (auto i{0uz}; i < bits; ++i)
+    EXPECT_ALL_EQ(timings[static_cast<dcc::tx::Timings::size_type>(i)],
+                  _packet_mock.transmit(),
+                  _timings_mock.transmit());
+
+  // Address is updated only when the next packet starts (after the cutout)
+  _packet_mock.transmit();
+  _timings_mock.transmit();
+
+  EXPECT_ALL_EQ(addr, _packet_mock.address(), _timings_mock.address());
+}
+
+TEST_F(TxTest, idle_address) {
+  _cfg.flags.bidi = false;
+  SetUp();
+
+  auto packet{dcc::make_idle_packet()};
+  auto timings{dcc::tx::packet2timings(packet, _cfg)};
+  auto bits{(_cfg.num_preamble +                  // Preamble
+             std::size(packet) * (1uz + CHAR_BIT) // Start + data
+             + 1uz) *                             // End
+            2uz};
+
+  // Try 3 idle packets
+  for (auto i{0uz}; i < bits * 3uz; ++i) {
+    EXPECT_ALL_EQ(timings[static_cast<dcc::tx::Timings::size_type>(i % bits)],
+                  _packet_mock.transmit(),
+                  _timings_mock.transmit());
+    EXPECT_ALL_EQ(dcc::decode_address(packet),
+                  _packet_mock.address(),
+                  _timings_mock.address());
+  }
+
+  // Address is updated only when the next packet starts (after the cutout)
+  _packet_mock.transmit();
+  _timings_mock.transmit();
+
+  EXPECT_ALL_EQ(dcc::decode_address(packet),
+                _packet_mock.address(),
+                _timings_mock.address());
+}
+
+TEST_F(TxTest, address_bidi_cutout) {
+  dcc::Address addr{.value = 3u, .type = dcc::Address::BasicLoco};
+
+  auto packet{dcc::make_128_speed_step_control_packet(addr, 0x00u)};
+  EXPECT_ALL_TRUE(_packet_mock.packet(packet), _timings_mock.packet(packet));
+  auto timings{dcc::tx::packet2timings(packet, _cfg)};
+  auto bits{(_cfg.num_preamble +                  // Preamble
+             std::size(packet) * (1uz + CHAR_BIT) // Start + data
+             + 1uz) *                             // End
+            2uz};
+
+  // Consume all timings, including BiDi
+  for (auto i{0uz}; i < bits; ++i)
+    EXPECT_ALL_EQ(timings[static_cast<dcc::tx::Timings::size_type>(i)],
+                  _packet_mock.transmit(),
+                  _timings_mock.transmit());
+  EXPECT_ALL_EQ(
+    static_cast<dcc::tx::Timings::value_type>(dcc::bidi::Timing::TCS),
+    _packet_mock.transmit(),
+    _timings_mock.transmit());
+  EXPECT_ALL_EQ(static_cast<dcc::tx::Timings::value_type>(
+                  dcc::bidi::Timing::TTS1 - dcc::bidi::Timing::TCS),
+                _packet_mock.transmit(),
+                _timings_mock.transmit());
+  EXPECT_ALL_EQ(static_cast<dcc::tx::Timings::value_type>(
+                  dcc::bidi::Timing::TTS2 - dcc::bidi::Timing::TTS1),
+                _packet_mock.transmit(),
+                _timings_mock.transmit());
+  EXPECT_ALL_EQ(static_cast<dcc::tx::Timings::value_type>(
+                  dcc::bidi::Timing::TTC2 - dcc::bidi::Timing::TTS2),
+                _packet_mock.transmit(),
+                _timings_mock.transmit());
+  EXPECT_ALL_EQ(static_cast<dcc::tx::Timings::value_type>(
+                  dcc::bidi::Timing::TCE - dcc::bidi::Timing::TTC2),
+                _packet_mock.transmit(),
+                _timings_mock.transmit());
+
+  // Address is updated only when the next packet starts (after the cutout)
+  _packet_mock.transmit();
+  _timings_mock.transmit();
+
+  EXPECT_ALL_EQ(addr, _packet_mock.address(), _timings_mock.address());
+}


### PR DESCRIPTION
Tracks the address of the previous transmission for usage in e.g. Railcom. 

/edit
Closes #140 