### PR TITLE
fix: `esp_linux_helper.h` is deprecated (#165)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   arm-none-eabi-gcc:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/arm-none-eabi-gcc.yml@v0.3.1
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/arm-none-eabi-gcc.yml@v0.3.2
     with:
       arch: -mcpu=cortex-m7
       target: DCCStm32Decoder DCCStm32CommandStation
@@ -42,7 +42,7 @@ jobs:
           target: esp32
 
   x86_64-linux-gnu-gcc:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.3.1
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.3.2
     with:
       pre-build: |
         sudo apt update -y

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   license:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/license-checker.yml@v0.3.1
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/license-checker.yml@v0.3.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         compliance: [OFF, ON]
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.3.1
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.3.2
     with:
       pre-build: |
         sudo apt update -y
@@ -21,7 +21,7 @@ jobs:
       post-build: ctest --test-dir build --schedule-random --timeout 86400
 
   include-what-you-must:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.3.1
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.3.2
     with:
       pre-build: |
         sudo apt update -y

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+##
+- Bugfix `esp_linux_helper.h` is deprecated ([#165](https://github.com/ZIMO-Elektronik/DCC/issues/165))
+
 ## 0.47.0
 - Short and long multi-function addresses don't compare equal ([#151](https://github.com/ZIMO-Elektronik/DCC/issues/151))
 - Clear CV29:5 when writing basic address to CV1 ([#151](https://github.com/ZIMO-Elektronik/DCC/issues/151))

--- a/src/rmt_dcc_encoder.c
+++ b/src/rmt_dcc_encoder.c
@@ -13,8 +13,9 @@
 #include <esp_check.h>
 #include <esp_heap_caps.h>
 #include <limits.h>
+#include <string.h>
 
-#if __has_include(<esp_linux_helper.h>)
+#if CONFIG_IDF_TARGET_LINUX && !defined(__containerof)
 #  include <esp_linux_helper.h>
 #endif
 


### PR DESCRIPTION
Closes #165 