### PR TITLE
fix: `bidi::Dissector` invalidates valid channel 2 data (#163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - 4th transmission of `app:decoder_unique` invokes `error()`
   - Unsupported SELECT queries are answered with 8x NAK
 - Remove high-current BiDi support (must be implemented by the user)
+- Bugfix `bidi::Dissector` invalidates valid channel 2 data ([#163](https://github.com/ZIMO-Elektronik/DCC/issues/163))
 - Bugfix `esp_linux_helper.h` is deprecated ([#165](https://github.com/ZIMO-Elektronik/DCC/issues/165))
 
 ## 0.47.0

--- a/include/dcc/bidi/dissector.hpp
+++ b/include/dcc/bidi/dissector.hpp
@@ -74,16 +74,34 @@ struct Dissector : std::ranges::view_interface<Dissector> {
   using iterator_category = std::input_iterator_tag;
 
   constexpr Dissector() = default;
+
   constexpr Dissector(Datagram<> encoded, Address addr)
     : _encoded{encoded}, _addr{addr} {
-    if (validate()) {
-      _decoded = decode_datagram(_encoded);
-      _i = static_cast<size_type>(
-        (_encoded[0uz] == 0u) +
-        (_encoded[1uz] == 0u)); // No channel 1 data if first two bytes are 0
-    } else
-      _i = std::numeric_limits<size_type>::max(); // No channel 1 and 2 data
+    // Validate channel 1 (popcount must be 4)
+    if (std::span<uint8_t, channel1_size> ch1{std::begin(_encoded),
+                                              std::begin(_encoded) + 2};
+        std::ranges::any_of(
+          ch1, [](uint8_t b) { return std::popcount(b) != CHAR_BIT / 2; })) {
+      std::ranges::fill(ch1, 0u);
+      _i = 2u; // Skip channel 1
+    }
+
+    // Validate channel 2 (popcount must be 4 or byte zero)
+    if (std::span<uint8_t, channel2_size> ch2{std::begin(_encoded) + 2,
+                                              std::end(_encoded)};
+        std::ranges::any_of(ch2, [](uint8_t b) {
+          return std::popcount(b) != CHAR_BIT / 2 && b;
+        })) {
+      std::ranges::fill(ch2, 0u);
+      if (_i == 2u) {
+        _i = std::numeric_limits<size_type>::max(); // Skip channel 1 and 2
+        return;
+      }
+    }
+
+    _decoded = decode_datagram(_encoded);
   }
+
   constexpr Dissector(Datagram<> encoded, Packet packet)
     : Dissector{encoded, decode_address(packet)} {}
 
@@ -219,12 +237,6 @@ struct Dissector : std::ranges::view_interface<Dissector> {
   }
 
 private:
-  constexpr bool validate() const {
-    return std::ranges::all_of(_encoded, [](uint8_t b) {
-      return !b || std::popcount(b) == CHAR_BIT / 2;
-    });
-  }
-
   constexpr std::span<uint8_t const> next() const {
     // No more data
     if (!_encoded[_i]) return {};

--- a/tests/bidi/dissector.cpp
+++ b/tests/bidi/dissector.cpp
@@ -110,49 +110,60 @@ TEST(Dissector, channel_1_and_2) {
 }
 
 TEST(Dissector, channel_1) {
-  {
-    dcc::Packet packet{0x03u, 0xA0u, 0xA3u};
-    Datagram<> datagram{0x99u, 0xA5u, 0x00u, 0x00u, 0x00u, 0x00u, 0x00u, 0x00u};
-    Dissector dissector{datagram, packet};
-    std::vector<Dissector::value_type> expected{
-      app::AdrLow{.d = 3u}}; // Address
-    std::vector<Dissector::value_type> result{};
-    std::ranges::copy(dissector, back_inserter(result));
-    EXPECT_EQ(expected, result);
-  }
+  dcc::Packet packet{0x03u, 0xA0u, 0xA3u};
+  Datagram<> datagram{0x99u, 0xA5u, 0x00u, 0x00u, 0x00u, 0x00u, 0x00u, 0x00u};
+  Dissector dissector{datagram, packet};
+  std::vector<Dissector::value_type> expected{app::AdrLow{.d = 3u}}; // Address
+  std::vector<Dissector::value_type> result{};
+  std::ranges::copy(dissector, back_inserter(result));
+  EXPECT_EQ(expected, result);
+}
+
+TEST(Dissector, channel_1_cant_contain_zeros) {
+  dcc::Packet packet{0x03u, 0xA0u, 0xA3u};
+  Datagram<> datagram{0x99u, 0x00u, 0x00u, 0x00u, 0x00u, 0x00u, 0x00u, 0x00u};
+  Dissector dissector{datagram, packet};
+  EXPECT_EQ(cbegin(dissector), cend(dissector));
 }
 
 TEST(Dissector, channel_2) {
-  {
-    dcc::Packet packet{0x03u, 0x3Fu, 0x80u, 0xBCu};
-    Datagram<> datagram{0x00u, 0x00u, 0x59u, 0xB1u, 0x66, 0x5Au, 0xACu, 0xACu};
-    Dissector dissector{datagram, packet};
-    std::vector<Dissector::value_type> expected{
-      app::Dyn{.d = 79u, .x = 26u}, // Temperature
-      app::Dyn{.d = 0u, .x = 0u}};  // Speed
-    std::vector<Dissector::value_type> result{};
-    std::ranges::copy(dissector, back_inserter(result));
-    EXPECT_EQ(expected, result);
-  }
-}
-
-TEST(Dissector, invalid) {
-  {
-    dcc::Packet packet{0x03u, 0x3Fu, 0x80u, 0xBCu};
-    Datagram<> datagram{0x00u, 0x00u, 0xD9u, 0xB1u, 0x66, 0x5Au, 0xACu, 0xACu};
-    Dissector dissector{datagram, packet};
-    std::vector<Dissector::value_type> expected{};
-    std::vector<Dissector::value_type> result{};
-    std::ranges::copy(dissector, back_inserter(result));
-    EXPECT_EQ(expected, result);
-  }
+  dcc::Packet packet{0x03u, 0x3Fu, 0x80u, 0xBCu};
+  Datagram<> datagram{0x00u, 0x00u, 0x59u, 0xB1u, 0x66, 0x5Au, 0xACu, 0xACu};
+  Dissector dissector{datagram, packet};
+  std::vector<Dissector::value_type> expected{
+    app::Dyn{.d = 79u, .x = 26u}, // Temperature
+    app::Dyn{.d = 0u, .x = 0u}};  // Speed
+  std::vector<Dissector::value_type> result{};
+  std::ranges::copy(dissector, back_inserter(result));
+  EXPECT_EQ(expected, result);
 }
 
 TEST(Dissector, unknown_id) {
-  {
-    dcc::Packet packet{0x03u, 0x3Fu, 0x80u, 0xBCu};
-    Datagram<> datagram{0x2Du, 0xCAu, 0x59u, 0x96u, 0x66u, 0x5Au, 0xACu, 0xACu};
-    Dissector dissector{datagram, packet};
-    EXPECT_EQ(cbegin(dissector), cend(dissector));
-  }
+  dcc::Packet packet{0x03u, 0x3Fu, 0x80u, 0xBCu};
+  Datagram<> datagram{0x2Du, 0xCAu, 0x59u, 0x96u, 0x66u, 0x5Au, 0xACu, 0xACu};
+  Dissector dissector{datagram, packet};
+  EXPECT_EQ(cbegin(dissector), cend(dissector));
+}
+
+TEST(Dissector, invalid_channel_2) {
+  dcc::Packet packet{0x03u, 0x3Fu, 0x80u, 0xBCu};
+  Datagram<> datagram{0x00u, 0x00u, 0xD9u, 0xB1u, 0x66, 0x5Au, 0xACu, 0xACu};
+  Dissector dissector{datagram, packet};
+  std::vector<Dissector::value_type> expected{};
+  std::vector<Dissector::value_type> result{};
+  std::ranges::copy(dissector, back_inserter(result));
+  EXPECT_EQ(expected, result);
+}
+
+TEST(Dissector, ignore_invalid_channel_1) {
+  dcc::Packet packet{0x03u, 0xDFu, 0x00u, 0xDCu};
+  Datagram<> datagram{0xA3u, 0xACu, 0x5Au, 0x74u, 0x5Cu, 0x5Au, 0xACu, 0xACu};
+  datagram[0uz] += 0b1u;
+  Dissector dissector{datagram, packet};
+  std::vector<Dissector::value_type> expected{
+    app::Dyn{.d = 19u, .x = 27u}, // Direction status byte
+    app::Dyn{.d = 0u, .x = 0u}};  // QoS
+  std::vector<Dissector::value_type> result{};
+  std::ranges::copy(dissector, back_inserter(result));
+  EXPECT_EQ(expected, result);
 }


### PR DESCRIPTION
Closes #163 